### PR TITLE
feat!: bump @tabler/icons@1 to @tabler/icons-react@2

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ View the full [Installation Docs](https://www.mantine-react-table.com/docs/getti
 2. Install Peer Dependencies (Mantine V5 and Tabler Icons)
 
 ```bash
-npm install @mantine/core @mantine/hooks @mantine/dates @emotion/react @tabler/icons dayjs
+npm install @mantine/core @mantine/hooks @mantine/dates @emotion/react @tabler/icons-react dayjs
 ```
 
 3. Install mantine-react-table

--- a/apps/mantine-react-table-docs/components/mdx/LinkHeading.tsx
+++ b/apps/mantine-react-table-docs/components/mdx/LinkHeading.tsx
@@ -10,7 +10,7 @@ import {
   TitleProps,
   Tooltip,
 } from '@mantine/core';
-import { IconLink } from '@tabler/icons';
+import { IconLink } from '@tabler/icons-react';
 
 interface Props extends TitleProps {
   children: ReactNode | string;

--- a/apps/mantine-react-table-docs/components/mdx/SourceCodeSnippet.tsx
+++ b/apps/mantine-react-table-docs/components/mdx/SourceCodeSnippet.tsx
@@ -9,7 +9,7 @@ import {
   IconBolt,
   IconBrandCodesandbox,
   IconExternalLink,
-} from '@tabler/icons';
+} from '@tabler/icons-react';
 import { LinkHeading } from './LinkHeading';
 import { usePlausible } from 'next-plausible';
 import { useThemeContext } from '../../styles/ThemeContext';

--- a/apps/mantine-react-table-docs/components/mdx/SuggestsEditsButton.tsx
+++ b/apps/mantine-react-table-docs/components/mdx/SuggestsEditsButton.tsx
@@ -1,6 +1,6 @@
 import { FC } from 'react';
 import { Anchor, Button, Stack, Text } from '@mantine/core';
-import { IconBrandGithub, IconEdit } from '@tabler/icons';
+import { IconBrandGithub, IconEdit } from '@tabler/icons-react';
 import { useRouter } from 'next/router';
 import { usePlausible } from 'next-plausible';
 

--- a/apps/mantine-react-table-docs/components/navigation/SidebarItems.tsx
+++ b/apps/mantine-react-table-docs/components/navigation/SidebarItems.tsx
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router';
 import Link from 'next/link';
 import { UnstyledButton, Flex } from '@mantine/core';
 import { useMediaQuery } from '@mantine/hooks';
-import { IconExternalLink } from '@tabler/icons';
+import { IconExternalLink } from '@tabler/icons-react';
 import { RouteItem } from './routes';
 import { getPrimaryColor } from 'mantine-react-table/src/column.utils';
 

--- a/apps/mantine-react-table-docs/components/navigation/TopBar.tsx
+++ b/apps/mantine-react-table-docs/components/navigation/TopBar.tsx
@@ -12,9 +12,9 @@ import {
   Burger,
   useMantineTheme,
 } from '@mantine/core';
-import { IconBrandGithub, IconBrandDiscord } from '@tabler/icons';
+import { IconBrandGithub, IconBrandDiscord } from '@tabler/icons-react';
 import { useMediaQuery } from '@mantine/hooks';
-import { IconSun, IconMoonStars } from '@tabler/icons';
+import { IconSun, IconMoonStars } from '@tabler/icons-react';
 import { useThemeContext } from '../../styles/ThemeContext';
 import docsearch from '@docsearch/js';
 import '@docsearch/css';

--- a/apps/mantine-react-table-docs/examples/advanced/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/advanced/sandbox/package.json
@@ -13,7 +13,7 @@
     "@mantine/core": "^5.10.0",
     "@mantine/dates": "^5.10.0",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "dayjs": "^1.11.7",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/advanced/sandbox/src/JS.js
+++ b/apps/mantine-react-table-docs/examples/advanced/sandbox/src/JS.js
@@ -10,7 +10,7 @@ import { Box, Button, Menu, Text, Title } from '@mantine/core';
 import { DatePicker } from '@mantine/dates';
 
 //Icons Imports
-import { IconUserCircle, IconSend } from '@tabler/icons';
+import { IconUserCircle, IconSend } from '@tabler/icons-react';
 
 //Mock Data
 import { data } from './makeData';

--- a/apps/mantine-react-table-docs/examples/advanced/sandbox/src/TS.tsx
+++ b/apps/mantine-react-table-docs/examples/advanced/sandbox/src/TS.tsx
@@ -10,7 +10,7 @@ import { Box, Button, Menu, Text, Title } from '@mantine/core';
 import { DatePicker } from '@mantine/dates';
 
 //Icons Imports
-import { IconUserCircle, IconSend } from '@tabler/icons';
+import { IconUserCircle, IconSend } from '@tabler/icons-react';
 
 //Mock Data
 import { data } from './makeData';

--- a/apps/mantine-react-table-docs/examples/aggregation-and-grouping/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/aggregation-and-grouping/sandbox/package.json
@@ -12,7 +12,7 @@
     "@emotion/react": "^11.10.5",
     "@mantine/core": "^5.10.0",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/apps/mantine-react-table-docs/examples/aggregation-multi/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/aggregation-multi/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/alternate-detail-panel/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/alternate-detail-panel/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/basic/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/basic/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/column-actions-space/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/column-actions-space/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/column-alignment/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/column-alignment/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/custom-top-toolbar/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/custom-top-toolbar/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/custom-top-toolbar/sandbox/src/JS.js
+++ b/apps/mantine-react-table-docs/examples/custom-top-toolbar/sandbox/src/JS.js
@@ -5,7 +5,7 @@ import {
   MRT_ToggleFullScreenButton,
 } from 'mantine-react-table';
 import { Box, Button, ActionIcon } from '@mantine/core';
-import { IconPrinter } from '@tabler/icons';
+import { IconPrinter } from '@tabler/icons-react';
 import { data } from './makeData';
 
 const Example = () => {

--- a/apps/mantine-react-table-docs/examples/custom-top-toolbar/sandbox/src/TS.tsx
+++ b/apps/mantine-react-table-docs/examples/custom-top-toolbar/sandbox/src/TS.tsx
@@ -6,7 +6,7 @@ import {
   MRT_ToggleFullScreenButton,
 } from 'mantine-react-table';
 import { Box, Button, ActionIcon } from '@mantine/core';
-import { IconPrinter } from '@tabler/icons';
+import { IconPrinter } from '@tabler/icons-react';
 import { data, Person } from './makeData';
 
 const Example: FC = () => {

--- a/apps/mantine-react-table-docs/examples/customize-display-columns/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/customize-display-columns/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/customize-filter-components/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/customize-filter-components/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/customize-filter-modes/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/customize-filter-modes/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/customize-filter-variants/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/customize-filter-variants/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/customize-global-filter-component/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/customize-global-filter-component/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/customize-row-selection/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/customize-row-selection/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/customize-table-styles/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/customize-table-styles/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/disable-column-actions/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/disable-column-actions/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/disable-column-filters/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/disable-column-filters/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/disable-column-hiding/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/disable-column-hiding/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/disable-density-toggle/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/disable-density-toggle/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/editing-crud/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/editing-crud/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/editing-crud/sandbox/src/JS.js
+++ b/apps/mantine-react-table-docs/examples/editing-crud/sandbox/src/JS.js
@@ -12,7 +12,7 @@ import {
   TextInput,
   Tooltip,
 } from '@mantine/core';
-import { IconTrash, IconEdit } from '@tabler/icons';
+import { IconTrash, IconEdit } from '@tabler/icons-react';
 import { data, states } from './makeData';
 
 const Example = () => {

--- a/apps/mantine-react-table-docs/examples/editing-crud/sandbox/src/TS.tsx
+++ b/apps/mantine-react-table-docs/examples/editing-crud/sandbox/src/TS.tsx
@@ -18,7 +18,7 @@ import {
   TextInput,
   Tooltip,
 } from '@mantine/core';
-import { IconTrash, IconEdit } from '@tabler/icons';
+import { IconTrash, IconEdit } from '@tabler/icons-react';
 import { data, states } from './makeData';
 
 export type Person = {

--- a/apps/mantine-react-table-docs/examples/enable-click-to-copy/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/enable-click-to-copy/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/enable-column-ordering/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/enable-column-ordering/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/enable-column-pinning/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/enable-column-pinning/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/enable-column-resizing/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/enable-column-resizing/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/enable-column-virtualization/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/enable-column-virtualization/sandbox/package.json
@@ -12,7 +12,7 @@
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
     "@faker-js/faker": "^7.6.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/enable-detail-panel/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/enable-detail-panel/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/enable-editing-cell/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/enable-editing-cell/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/enable-editing-modal/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/enable-editing-modal/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/enable-editing-row/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/enable-editing-row/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/enable-editing-table/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/enable-editing-table/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/enable-expanding-tree/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/enable-expanding-tree/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/enable-row-dragging/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/enable-row-dragging/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/enable-row-numbers-original/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/enable-row-numbers-original/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/enable-row-numbers-static/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/enable-row-numbers-static/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/enable-row-ordering/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/enable-row-ordering/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/enable-row-selection/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/enable-row-selection/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/enable-row-virtualization/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/enable-row-virtualization/sandbox/package.json
@@ -12,7 +12,7 @@
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
     "@faker-js/faker": "^7.6.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/enable-sticky-header/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/enable-sticky-header/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/expanding-tree-expanded/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/expanding-tree-expanded/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/export-to-csv/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/export-to-csv/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "export-to-csv": "^0.2.1",
     "mantine-react-table": "^0.6.1",

--- a/apps/mantine-react-table-docs/examples/export-to-csv/sandbox/src/JS.js
+++ b/apps/mantine-react-table-docs/examples/export-to-csv/sandbox/src/JS.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { MantineReactTable } from 'mantine-react-table';
 import { Box, Button } from '@mantine/core';
-import { IconDownload } from '@tabler/icons';
+import { IconDownload } from '@tabler/icons-react';
 import { ExportToCsv } from 'export-to-csv'; //or use your library of choice here
 import { data } from './makeData';
 

--- a/apps/mantine-react-table-docs/examples/export-to-csv/sandbox/src/TS.tsx
+++ b/apps/mantine-react-table-docs/examples/export-to-csv/sandbox/src/TS.tsx
@@ -1,7 +1,7 @@
 import React, { FC } from 'react';
 import { MantineReactTable, MRT_ColumnDef, MRT_Row } from 'mantine-react-table';
 import { Box, Button } from '@mantine/core';
-import { IconDownload } from '@tabler/icons';
+import { IconDownload } from '@tabler/icons-react';
 import { ExportToCsv } from 'export-to-csv'; //or use your library of choice here
 import { data, Person } from './makeData';
 

--- a/apps/mantine-react-table-docs/examples/external-toolbar/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/external-toolbar/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/external-toolbar/sandbox/src/JS.js
+++ b/apps/mantine-react-table-docs/examples/external-toolbar/sandbox/src/JS.js
@@ -10,7 +10,7 @@ import {
   MRT_ToolbarAlertBanner,
 } from 'mantine-react-table';
 import { ActionIcon, Box, Button, Flex, Text, Tooltip } from '@mantine/core';
-import { IconPrinter } from '@tabler/icons';
+import { IconPrinter } from '@tabler/icons-react';
 import { data } from './makeData';
 
 //column definitions...

--- a/apps/mantine-react-table-docs/examples/external-toolbar/sandbox/src/TS.tsx
+++ b/apps/mantine-react-table-docs/examples/external-toolbar/sandbox/src/TS.tsx
@@ -18,7 +18,7 @@ import type {
   VisibilityState,
 } from '@tanstack/react-table';
 import { ActionIcon, Box, Button, Flex, Text, Tooltip } from '@mantine/core';
-import { IconPrinter } from '@tabler/icons';
+import { IconPrinter } from '@tabler/icons-react';
 import { data, Person } from './makeData';
 
 //column definitions...

--- a/apps/mantine-react-table-docs/examples/font-awesome-icons/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/font-awesome-icons/sandbox/package.json
@@ -14,7 +14,7 @@
     "@fortawesome/fontawesome-svg-core": "^6.2.1",
     "@fortawesome/free-solid-svg-icons": "^6.2.1",
     "@fortawesome/react-fontawesome": "^0.2.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/infinite-scrolling/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/infinite-scrolling/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "@tanstack/react-query": "^4.22.0",
     "mantine-react-table": "^0.6.1",

--- a/apps/mantine-react-table-docs/examples/linear-progress/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/linear-progress/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/loading/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/loading/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/localization-i18n-cs/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/localization-i18n-cs/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/localization-i18n-da/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/localization-i18n-da/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/localization-i18n-de/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/localization-i18n-de/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/localization-i18n-en/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/localization-i18n-en/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/localization-i18n-es/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/localization-i18n-es/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/localization-i18n-fa/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/localization-i18n-fa/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/localization-i18n-fr/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/localization-i18n-fr/sandbox/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@emotion/react": "^11.10.5",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@mantine/core": "^5.10.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/localization-i18n-it/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/localization-i18n-it/sandbox/package.json
@@ -12,7 +12,7 @@
     "@emotion/react": "^11.10.5",
     "@mantine/core": "^5.10.0",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/apps/mantine-react-table-docs/examples/localization-i18n-ja/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/localization-i18n-ja/sandbox/package.json
@@ -12,7 +12,7 @@
     "@emotion/react": "^11.10.5",
     "@mantine/core": "^5.10.0",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/apps/mantine-react-table-docs/examples/localization-i18n-nl/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/localization-i18n-nl/sandbox/package.json
@@ -12,7 +12,7 @@
     "@emotion/react": "^11.10.5",
     "@mantine/core": "^5.10.0",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/apps/mantine-react-table-docs/examples/localization-i18n-pl/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/localization-i18n-pl/sandbox/package.json
@@ -12,7 +12,7 @@
     "@emotion/react": "^11.10.5",
     "@mantine/core": "^5.10.0",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/apps/mantine-react-table-docs/examples/localization-i18n-pt-BR/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/localization-i18n-pt-BR/sandbox/package.json
@@ -12,7 +12,7 @@
     "@emotion/react": "^11.10.5",
     "@mantine/core": "^5.10.0",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/apps/mantine-react-table-docs/examples/localization-i18n-pt/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/localization-i18n-pt/sandbox/package.json
@@ -12,7 +12,7 @@
     "@emotion/react": "^11.10.5",
     "@mantine/core": "^5.10.0",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/apps/mantine-react-table-docs/examples/localization-i18n-ro/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/localization-i18n-ro/sandbox/package.json
@@ -12,7 +12,7 @@
     "@emotion/react": "^11.10.5",
     "@mantine/core": "^5.10.0",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/apps/mantine-react-table-docs/examples/localization-i18n-ru/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/localization-i18n-ru/sandbox/package.json
@@ -12,7 +12,7 @@
     "@emotion/react": "^11.10.5",
     "@mantine/core": "^5.10.0",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/apps/mantine-react-table-docs/examples/localization-i18n-tr/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/localization-i18n-tr/sandbox/package.json
@@ -12,7 +12,7 @@
     "@emotion/react": "^11.10.5",
     "@mantine/core": "^5.10.0",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/apps/mantine-react-table-docs/examples/localization-i18n-vi/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/localization-i18n-vi/sandbox/package.json
@@ -12,7 +12,7 @@
     "@emotion/react": "^11.10.5",
     "@mantine/core": "^5.10.0",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/apps/mantine-react-table-docs/examples/localization-i18n-zh-hans/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/localization-i18n-zh-hans/sandbox/package.json
@@ -12,7 +12,7 @@
     "@emotion/react": "^11.10.5",
     "@mantine/core": "^5.10.0",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/apps/mantine-react-table-docs/examples/localization-i18n-zh-hant/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/localization-i18n-zh-hant/sandbox/package.json
@@ -12,7 +12,7 @@
     "@emotion/react": "^11.10.5",
     "@mantine/core": "^5.10.0",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/apps/mantine-react-table-docs/examples/mantine-theme/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/mantine-theme/sandbox/package.json
@@ -12,7 +12,7 @@
     "@emotion/react": "^11.10.5",
     "@mantine/core": "^5.10.0",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/apps/mantine-react-table-docs/examples/manual-selection/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/manual-selection/sandbox/package.json
@@ -12,7 +12,7 @@
     "@emotion/react": "^11.10.5",
     "@mantine/core": "^5.10.0",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/apps/mantine-react-table-docs/examples/memoize-cells/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/memoize-cells/sandbox/package.json
@@ -12,7 +12,7 @@
     "@emotion/react": "^11.10.5",
     "@mantine/core": "^5.10.0",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/apps/mantine-react-table-docs/examples/memoize-rows/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/memoize-rows/sandbox/package.json
@@ -12,7 +12,7 @@
     "@emotion/react": "^11.10.5",
     "@mantine/core": "^5.10.0",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/apps/mantine-react-table-docs/examples/memoize-table-body/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/memoize-table-body/sandbox/package.json
@@ -12,7 +12,7 @@
     "@emotion/react": "^11.10.5",
     "@mantine/core": "^5.10.0",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/apps/mantine-react-table-docs/examples/minimal/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/minimal/sandbox/package.json
@@ -12,7 +12,7 @@
     "@emotion/react": "^11.10.5",
     "@mantine/core": "^5.10.0",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/apps/mantine-react-table-docs/examples/react-query/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/react-query/sandbox/package.json
@@ -12,7 +12,7 @@
     "@emotion/react": "^11.10.5",
     "@mantine/core": "^5.10.0",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@tanstack/react-query": "^4.22.0",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",

--- a/apps/mantine-react-table-docs/examples/react-query/sandbox/src/JS.js
+++ b/apps/mantine-react-table-docs/examples/react-query/sandbox/src/JS.js
@@ -1,7 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { MantineReactTable } from 'mantine-react-table';
 import { ActionIcon, Tooltip } from '@mantine/core';
-import { IconRefresh } from '@tabler/icons';
+import { IconRefresh } from '@tabler/icons-react';
 import {
   QueryClient,
   QueryClientProvider,

--- a/apps/mantine-react-table-docs/examples/react-query/sandbox/src/TS.tsx
+++ b/apps/mantine-react-table-docs/examples/react-query/sandbox/src/TS.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useMemo, useState } from 'react';
 import { MantineReactTable, MRT_ColumnDef } from 'mantine-react-table';
 import { ActionIcon, Tooltip } from '@mantine/core';
-import { IconRefresh } from '@tabler/icons';
+import { IconRefresh } from '@tabler/icons-react';
 import type {
   ColumnFiltersState,
   PaginationState,

--- a/apps/mantine-react-table-docs/examples/remote/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/remote/sandbox/package.json
@@ -12,7 +12,7 @@
     "@emotion/react": "^11.10.5",
     "@mantine/core": "^5.10.0",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/apps/mantine-react-table-docs/examples/single-row-selection/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/single-row-selection/sandbox/package.json
@@ -12,7 +12,7 @@
     "@emotion/react": "^11.10.5",
     "@mantine/core": "^5.10.0",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/apps/mantine-react-table-docs/examples/virtualized/sandbox/package.json
+++ b/apps/mantine-react-table-docs/examples/virtualized/sandbox/package.json
@@ -13,7 +13,7 @@
     "@faker-js/faker": "^7.6.0",
     "@mantine/core": "^5.10.0",
     "@mantine/hooks": "^5.10.0",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "mantine-react-table": "^0.6.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/apps/mantine-react-table-docs/package.json
+++ b/apps/mantine-react-table-docs/package.json
@@ -27,7 +27,7 @@
     "@mdx-js/loader": "^2.2.1",
     "@mdx-js/react": "^2.2.1",
     "@next/mdx": "^13.1.2",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@tanstack/react-query": "^4.22.0",
     "@tanstack/react-table": "8.7.9",
     "@tanstack/react-virtual": "3.0.0-beta.30",

--- a/apps/mantine-react-table-docs/pages/docs/getting-started/install.mdx
+++ b/apps/mantine-react-table-docs/pages/docs/getting-started/install.mdx
@@ -47,19 +47,19 @@ yarn add mantine-react-table
 NPM
 
 ```bash
-npm install mantine-react-table @mantine/core @mantine/hooks @mantine/dates @emotion/react @tabler/icons dayjs
+npm install mantine-react-table @mantine/core @mantine/hooks @mantine/dates @emotion/react @tabler/icons-react dayjs
 ```
 
 PNPM
 
 ```bash
-pnpm add mantine-react-table @mantine/core @mantine/hooks @mantine/dates @emotion/react @tabler/icons dayjs
+pnpm add mantine-react-table @mantine/core @mantine/hooks @mantine/dates @emotion/react @tabler/icons-react dayjs
 ```
 
 Yarn
 
 ```bash
-yarn add mantine-react-table @mantine/core @mantine/hooks @mantine/dates @emotion/react @tabler/icons dayjs
+yarn add mantine-react-table @mantine/core @mantine/hooks @mantine/dates @emotion/react @tabler/icons-react dayjs
 ```
 
 > You do NOT need to install `@tanstack/react-table`, as it is already an internal dependency of `mantine-react-table`, and must use an exact version already specified internally.

--- a/apps/mantine-react-table-docs/pages/index.tsx
+++ b/apps/mantine-react-table-docs/pages/index.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import { Anchor, Box, Button, Stack, Text, Title } from '@mantine/core';
-import { IconChevronRight } from '@tabler/icons';
+import { IconChevronRight } from '@tabler/icons-react';
 import { HomeCards } from '../components/mdx/HomeCards';
 import { LinkCards } from '../components/mdx/LinkCards';
 import { StatBadges } from '../components/mdx/StatBadges';
@@ -254,7 +254,7 @@ const HomePage = () => {
         <Box py="16px">
           <SampleCodeSnippet className="language-bash">
             npm install mantine-react-table @mantine/core @mantine/hooks
-            @mantine/dates @emotion/react @tabler/icons dayjs
+            @mantine/dates @emotion/react @tabler/icons-react dayjs
           </SampleCodeSnippet>
         </Box>
         <HomeCards />

--- a/apps/mantine-react-table-storybook/package.json
+++ b/apps/mantine-react-table-storybook/package.json
@@ -36,7 +36,7 @@
     "@mantine/core": "^5.10.1",
     "@mantine/dates": "^5.10.1",
     "@mantine/hooks": "^5.10.1",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@tanstack/react-table": "8.7.9",
     "dayjs": "^1.11.7",
     "mantine-react-table": "workspace:*",

--- a/apps/mantine-react-table-storybook/stories/features/RowActions.stories.tsx
+++ b/apps/mantine-react-table-storybook/stories/features/RowActions.stories.tsx
@@ -7,7 +7,7 @@ import {
 } from 'mantine-react-table';
 import { faker } from '@faker-js/faker';
 import { Button, Menu } from '@mantine/core';
-import { IconShare, IconUser, IconTrash } from '@tabler/icons';
+import { IconShare, IconUser, IconTrash } from '@tabler/icons-react';
 
 const meta: Meta = {
   title: 'Features/Row Actions Examples',

--- a/apps/mantine-react-table-storybook/stories/features/Toolbar.stories.tsx
+++ b/apps/mantine-react-table-storybook/stories/features/Toolbar.stories.tsx
@@ -8,7 +8,7 @@ import {
 } from 'mantine-react-table';
 import { faker } from '@faker-js/faker';
 import { Box, Button, ActionIcon, Tooltip, Title } from '@mantine/core';
-import { IconPlus, IconTrash } from '@tabler/icons';
+import { IconPlus, IconTrash } from '@tabler/icons-react';
 
 const meta: Meta = {
   title: 'Features/Toolbar Examples',

--- a/packages/mantine-react-table/README.md
+++ b/packages/mantine-react-table/README.md
@@ -107,7 +107,7 @@ View the full [Installation Docs](https://www.mantine-react-table.com/docs/getti
 2. Install Peer Dependencies (Mantine V5 and Tabler Icons)
 
 ```bash
-npm install @mantine/core @mantine/hooks @mantine/dates @emotion/react @tabler/icons dayjs
+npm install @mantine/core @mantine/hooks @mantine/dates @emotion/react @tabler/icons-react dayjs
 ```
 
 3. Install mantine-react-table

--- a/packages/mantine-react-table/package.json
+++ b/packages/mantine-react-table/package.json
@@ -63,7 +63,7 @@
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@rollup/plugin-typescript": "^11.0.0",
     "@size-limit/preset-small-lib": "^8.1.1",
-    "@tabler/icons": "1.119.0",
+    "@tabler/icons-react": "2.1.2",
     "@types/node": "^18.11.18",
     "@types/react": "^18.0.26",
     "@types/react-dom": "^18.0.10",
@@ -87,7 +87,7 @@
     "@mantine/core": ">=5",
     "@mantine/dates": ">=5",
     "@mantine/hooks": ">=5",
-    "@tabler/icons": ">=1.118",
+    "@tabler/icons-react": ">=2",
     "react": ">=17.0",
     "react-dom": ">=17.0"
   },

--- a/packages/mantine-react-table/rollup.config.mjs
+++ b/packages/mantine-react-table/rollup.config.mjs
@@ -33,7 +33,7 @@ export default [
       '@mantine/core',
       '@mantine/dates',
       '@mantine/hooks',
-      '@tabler/icons',
+      '@tabler/icons-react',
       '@tanstack/match-sorter-utils',
       '@tanstack/react-table',
       '@tanstack/react-virtual',

--- a/packages/mantine-react-table/src/head/MRT_TableHeadCellFilterContainer.tsx
+++ b/packages/mantine-react-table/src/head/MRT_TableHeadCellFilterContainer.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 import { ActionIcon, Collapse, Flex, Menu, Text, Tooltip } from '@mantine/core';
-import { IconFilter } from '@tabler/icons';
+import { IconFilter } from '@tabler/icons-react';
 import { MRT_FilterRangeFields } from '../inputs/MRT_FilterRangeFields';
 import { MRT_FilterTextInput } from '../inputs/MRT_FilterTextInput';
 import { MRT_FilterCheckbox } from '../inputs/MRT_FilterCheckbox';

--- a/packages/mantine-react-table/src/icons.ts
+++ b/packages/mantine-react-table/src/icons.ts
@@ -33,7 +33,7 @@ import {
   IconTallymark4,
   IconTallymarks,
   IconX,
-} from '@tabler/icons';
+} from '@tabler/icons-react';
 
 export interface MRT_Icons {
   IconArrowAutofitContent: any;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,7 +27,7 @@ importers:
       '@mdx-js/loader': ^2.2.1
       '@mdx-js/react': ^2.2.1
       '@next/mdx': ^13.1.2
-      '@tabler/icons': 1.119.0
+      '@tabler/icons-react': 2.1.2
       '@tanstack/react-query': ^4.22.0
       '@tanstack/react-table': 8.7.9
       '@tanstack/react-virtual': 3.0.0-beta.30
@@ -63,7 +63,7 @@ importers:
       '@mdx-js/loader': 2.2.1
       '@mdx-js/react': 2.2.1_react@18.2.0
       '@next/mdx': 13.1.2_vvg67iglxhejglpl7nsv3pjzui
-      '@tabler/icons': 1.119.0_biqbaboplfbrettd7655fr4n2y
+      '@tabler/icons-react': 2.1.2_react@18.2.0
       '@tanstack/react-query': 4.22.0_biqbaboplfbrettd7655fr4n2y
       '@tanstack/react-table': 8.7.9_biqbaboplfbrettd7655fr4n2y
       '@tanstack/react-virtual': 3.0.0-beta.30_react@18.2.0
@@ -104,7 +104,7 @@ importers:
       '@storybook/builder-webpack5': ^6.5.15
       '@storybook/manager-webpack5': ^6.5.15
       '@storybook/react': ^6.5.15
-      '@tabler/icons': 1.119.0
+      '@tabler/icons-react': 2.1.2
       '@tanstack/react-table': 8.7.9
       '@types/node': ^18.11.18
       '@types/react': ^18.0.26
@@ -125,7 +125,7 @@ importers:
       '@mantine/core': 5.10.1_vmfc4eynrtlwqan3hg7ts62b2m
       '@mantine/dates': 5.10.1_bpk7vfbxhpsvcdizyj7sptmxnq
       '@mantine/hooks': 5.10.1_react@18.2.0
-      '@tabler/icons': 1.119.0_biqbaboplfbrettd7655fr4n2y
+      '@tabler/icons-react': 2.1.2_react@18.2.0
       '@tanstack/react-table': 8.7.9_biqbaboplfbrettd7655fr4n2y
       dayjs: 1.11.7
       mantine-react-table: link:../../packages/mantine-react-table
@@ -166,7 +166,7 @@ importers:
       '@rollup/plugin-node-resolve': ^15.0.1
       '@rollup/plugin-typescript': ^11.0.0
       '@size-limit/preset-small-lib': ^8.1.1
-      '@tabler/icons': 1.119.0
+      '@tabler/icons-react': 2.1.2
       '@tanstack/match-sorter-utils': 8.7.6
       '@tanstack/react-table': 8.7.9
       '@tanstack/react-virtual': 3.0.0-beta.30
@@ -204,7 +204,7 @@ importers:
       '@rollup/plugin-node-resolve': 15.0.1_rollup@3.10.0
       '@rollup/plugin-typescript': 11.0.0_6xbyoujvh6bzbrau3o3neoxpya
       '@size-limit/preset-small-lib': 8.1.1_size-limit@8.1.1
-      '@tabler/icons': 1.119.0_biqbaboplfbrettd7655fr4n2y
+      '@tabler/icons-react': 2.1.2_react@18.2.0
       '@types/node': 18.11.18
       '@types/react': 18.0.26
       '@types/react-dom': 18.0.10
@@ -4777,19 +4777,17 @@ packages:
     dependencies:
       tslib: 2.4.1
 
-  /@tabler/icons/1.119.0_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-Fk3Qq4w2SXcTjc/n1cuL5bccPkylrOMo7cYpQIf/yw6zP76LQV9dtLcHQUjFiUnaYuswR645CnURIhlafyAh9g==}
+  /@tabler/icons-react/2.1.2_react@18.2.0:
+    resolution: {integrity: sha512-DrJrr7e7+tzsqm3KFw1gg9Pfapz+gNA2bwv78tdlMKVQ5G6bfEtKVugzqqpgLfCJN/CgcM1ZROGrLtdmV/O6gw==}
     peerDependencies:
-      react: ^16.x || 17.x || 18.x
-      react-dom: ^16.x || 17.x || 18.x
-    peerDependenciesMeta:
-      react:
-        optional: true
-      react-dom:
-        optional: true
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0
     dependencies:
+      '@tabler/icons': 2.1.2
+      prop-types: 15.8.1
       react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
+
+  /@tabler/icons/2.1.2:
+    resolution: {integrity: sha512-+CPB+BSqVDP4+/d+cHSaGwG460C3sob7EJkQ+ZS8xV6bRER64OsCP92O7M+uYBhJFDWuf6poCeSETNZNcFa2nA==}
 
   /@tanstack/match-sorter-utils/8.7.6:
     resolution: {integrity: sha512-2AMpRiA6QivHOUiBpQAVxjiHAA68Ei23ZUMNaRJrN6omWiSFLoYrxGcT6BXtuzp0Jw4h6HZCmGGIM/gbwebO2A==}


### PR DESCRIPTION
I followed the current doc but found @tabler/icons has been v2 as latest, which results in unexpected layouts (plain svg texts).

Following [@tabler/icons v2 changelog](https://github.com/tabler/tabler-icons/releases/tag/v2.0.0), we should upgrade this package.