### PR TITLE
Update MantineReactTable.tsx

### DIFF
--- a/packages/mantine-react-table/src/MantineReactTable.tsx
+++ b/packages/mantine-react-table/src/MantineReactTable.tsx
@@ -680,7 +680,7 @@ export type MantineReactTableProps<TData extends Record<string, any> = {}> =
      */
     defaultDisplayColumn?: Partial<MRT_ColumnDef<TData>>;
     displayColumnDefOptions?: Partial<{
-      [key in MRT_DisplayColumnIds]: Partial<MRT_ColumnDef>;
+      [key in MRT_DisplayColumnIds]: Partial<MRT_ColumnDef<TData>>;
     }>;
     editingMode?: 'table' | 'modal' | 'row' | 'cell';
     enableBottomToolbar?: boolean;


### PR DESCRIPTION
I've been struggling with the missing "TData" :

![image](https://user-images.githubusercontent.com/124669197/228575738-9510ecac-7b30-4cdf-af86-08caf79455e5.png)

So, if there's nothing wrong with that, I propose that we add "TData" to "displayColumnDefOptions" definition