### PR TITLE
fix: fixing docs to correct classname

### DIFF
--- a/apps/mantine-react-table-docs/examples/column-actions-space/sandbox/src/JS.js
+++ b/apps/mantine-react-table-docs/examples/column-actions-space/sandbox/src/JS.js
@@ -28,7 +28,7 @@ const Example = () => {
       data={data}
       mantineTableHeadCellProps={{
         sx: {
-          '& .Mantine-TableHeadCell-Content': {
+          '& .mantine-TableHeadCell-Content': {
             justifyContent: 'space-between',
           },
         },

--- a/apps/mantine-react-table-docs/examples/column-actions-space/sandbox/src/TS.tsx
+++ b/apps/mantine-react-table-docs/examples/column-actions-space/sandbox/src/TS.tsx
@@ -28,7 +28,7 @@ const Example = () => {
       data={data}
       mantineTableHeadCellProps={{
         sx: {
-          '& .Mantine-TableHeadCell-Content': {
+          '& .mantine-TableHeadCell-Content': {
             justifyContent: 'space-between',
           },
         },


### PR DESCRIPTION
# Changelog

Hey @KevinVandy  just found a typo as I was reading the docs, not sure if its intended or not, but here it is

![image](https://user-images.githubusercontent.com/50872387/230069313-af5fb593-2fe9-488f-a97c-f81020653a5b.png)
