### PR TITLE
Update pagination markdown to use strings as `rowsPerPageOptions`

### DIFF
--- a/apps/mantine-react-table-docs/pages/docs/guides/pagination.mdx
+++ b/apps/mantine-react-table-docs/pages/docs/guides/pagination.mdx
@@ -65,7 +65,7 @@ You can customize the pagination component with the `mantinePaginationProps` pro
   columns={columns}
   data={data}
   mantinePaginationProps={{
-    rowsPerPageOptions: [5, 10],
+    rowsPerPageOptions: ["5", "10"],
     showFirstLastPageButtons: false,
   }}
 />


### PR DESCRIPTION
The type defined for the `rowsPerPageOptions` by the `mantinePaginationProps` is `string[]`. The example should therefore provide the numbers as strings