### PR TITLE
Update row-actions markdown to use `Menu.Item`

### DIFF
--- a/apps/mantine-react-table-docs/pages/docs/guides/row-actions.mdx
+++ b/apps/mantine-react-table-docs/pages/docs/guides/row-actions.mdx
@@ -43,8 +43,8 @@ If you want to embed all of your row actions into a single menu, then you can us
 <MantineReactTable
   enableRowActions
   renderRowActionMenuItems={({row}) => [
-      <MenuItem onClick={() => console.info('Edit')}>Edit</MenuItem>,
-      <MenuItem onClick={() => console.info('Delete')}>Delete</MenuItem>
+      <Menu.Item onClick={() => console.info('Edit')}>Edit</Menu.Item>,
+      <Menu.Item onClick={() => console.info('Delete')}>Delete</Menu.Item>
     ]
   )}
 />


### PR DESCRIPTION
As stated by the mantine v6 documentation, the menu exposes menu items via `Menu.Item`. This should be reflected in the documentation