### PR TITLE
Increase Z-Index of MRT_TopToolbar

### DIFF
--- a/packages/mantine-react-table/src/toolbar/MRT_TopToolbar.tsx
+++ b/packages/mantine-react-table/src/toolbar/MRT_TopToolbar.tsx
@@ -20,7 +20,7 @@ export const commonToolbarStyles = ({ theme }: { theme: MantineTheme }) => ({
   overflow: 'visible',
   padding: '0 !important',
   transition: 'all 100ms ease-in-out',
-  zIndex: 1,
+  zIndex: 3,
 });
 
 interface Props<TData extends Record<string, any> = {}> {


### PR DESCRIPTION
Increase Z-index of TopToolbar so that it is always infront if the header.