### PR TITLE
Only call renderDetailPanel when row detail is expanded

### DIFF
--- a/packages/mantine-react-table/src/body/MRT_TableDetailPanel.tsx
+++ b/packages/mantine-react-table/src/body/MRT_TableDetailPanel.tsx
@@ -84,7 +84,7 @@ export const MRT_TableDetailPanel = ({
       >
         {renderDetailPanel && (
           <Collapse in={row.getIsExpanded()}>
-            {!isLoading && renderDetailPanel({ row, table })}
+            {!isLoading && row.getIsExpanded() && renderDetailPanel({ row, table })}
           </Collapse>
         )}
       </Box>


### PR DESCRIPTION
The `renderDetailPanel` handler function should only be called when the details pane is expanded, i.e. visible.  