### PR TITLE
add ghost row

### DIFF
--- a/packages/mantine-react-table/src/GhostRow.ts
+++ b/packages/mantine-react-table/src/GhostRow.ts
@@ -1,0 +1,218 @@
+import { type MantineTheme } from '@mantine/core';
+import { type CSSProperties } from 'react';
+
+type Position = {
+  x: number;
+  y: number;
+};
+
+type StylesToClone = (keyof CSSProperties)[];
+
+export type GhostRowProps = {
+  enabled?: boolean;
+  className?: string;
+  rowStylesToClone?: StylesToClone;
+  cellStylesToClone?: StylesToClone;
+  rowStyle?:
+    | CSSProperties
+    | ((props: { theme: MantineTheme }) => CSSProperties);
+  cellStyle?:
+    | CSSProperties
+    | ((props: { theme: MantineTheme }) => CSSProperties);
+};
+
+type GhostRowCreate = (props: {
+  row: HTMLTableRowElement;
+  startX: number;
+  startY: number;
+  className?: string;
+  rowStylesToClone?: StylesToClone;
+  cellStylesToClone?: StylesToClone;
+  rowStyle?: CSSProperties;
+  cellStyle?: CSSProperties;
+}) => void;
+
+function isCSSProperty(key: any): key is keyof CSSStyleDeclaration {
+  return key in document.body.style;
+}
+
+export class GhostRow {
+  #ghostNode: HTMLTableRowElement | null = null;
+  #grabHandleOffset: Position = { x: 0, y: 0 };
+  #mousePos: Position = { x: 0, y: 0 };
+  #isFirefox: boolean;
+  #defaultRowCssPropsToClone: StylesToClone;
+  #defaultCellCssPropsToClone: StylesToClone;
+
+  static instance: GhostRow | null = null;
+
+  static getInstance() {
+    if (!GhostRow.instance) {
+      GhostRow.instance = new GhostRow();
+    }
+    return GhostRow.instance;
+  }
+
+  private constructor() {
+    // Check if browser is firefox, it doesn't fire mousemove events on drag
+    this.#isFirefox = navigator.userAgent.toLowerCase().includes('firefox');
+    this.#defaultRowCssPropsToClone = [
+      'display',
+      'alignItems',
+      'verticalAlign',
+      'borderCollapse',
+    ];
+    this.#defaultCellCssPropsToClone = [
+      'minWidth',
+      'paddingTop',
+      'paddingBottom',
+      'paddingLeft',
+      'paddingRight',
+      'fontSize',
+      'fontFamily',
+      'fontWeight',
+      'lineHeight',
+      'letterSpacing',
+      'verticalAlign',
+    ];
+  }
+
+  #cloneStyles(
+    stylesToClone: StylesToClone,
+    sourceStyle: CSSStyleDeclaration,
+    targetStyle: CSSStyleDeclaration,
+  ) {
+    stylesToClone.forEach((prop) => {
+      if (isCSSProperty(prop)) {
+        targetStyle[prop as any] = sourceStyle[prop as any];
+      }
+    });
+  }
+
+  #cloneRowStyles(
+    row: HTMLTableRowElement,
+    clonedRow: HTMLTableRowElement,
+    rowStylesToClone: StylesToClone,
+  ): void {
+    const rowStylesToCloneWithDefaults = Array.from(
+      new Set([...this.#defaultRowCssPropsToClone, ...rowStylesToClone]),
+    );
+    const rowStyles = getComputedStyle(row);
+    this.#cloneStyles(rowStylesToCloneWithDefaults, rowStyles, clonedRow.style);
+  }
+
+  #cloneCellStyles(
+    row: HTMLTableRowElement,
+    clonedRow: HTMLTableRowElement,
+    cellStylesToClone: StylesToClone,
+  ): void {
+    const cellStylesToCloneWithDefaults = Array.from(
+      new Set([...this.#defaultCellCssPropsToClone, ...cellStylesToClone]),
+    );
+    row.childNodes.forEach((cell, index) => {
+      const clonedCell = clonedRow.childNodes[index] as HTMLElement;
+      const cellStyles = getComputedStyle(cell as HTMLElement);
+      const width = (cell as HTMLElement).offsetWidth;
+      clonedCell.style.width = `${width}px`;
+      this.#cloneStyles(
+        cellStylesToCloneWithDefaults,
+        cellStyles,
+        clonedCell.style,
+      );
+    });
+  }
+
+  #applyCustomStyles(element: HTMLElement, style: CSSProperties): void {
+    Object.entries(style).forEach(([key, value]) => {
+      if (isCSSProperty(key)) (element.style as any)[key] = value;
+    });
+  }
+
+  #addGhostClasses(clonedRow: HTMLTableRowElement, className: string): void {
+    clonedRow.classList.add('ghost-row');
+    if (className) {
+      clonedRow.classList.add(className);
+    }
+  }
+
+  #addGhostStyles(
+    clonedRow: HTMLTableRowElement,
+    startY: number,
+    width: number,
+  ): void {
+    const x = -9999;
+    const y = startY - this.#grabHandleOffset.y;
+    clonedRow.style.width = `${width}px`;
+    clonedRow.style.alignItems = 'center';
+    clonedRow.style.transform = `translate(${x}px, ${y}px)`;
+    clonedRow.style.transition = 'none';
+    clonedRow.style.pointerEvents = 'none';
+    clonedRow.style.position = 'fixed';
+    clonedRow.style.zIndex = '9999';
+    clonedRow.style.top = '0';
+  }
+
+  #addGhostRowToDom = (ghostRow: HTMLElement) => {
+    // Firefox doesn't fire mousemove events on drag
+    if (this.#isFirefox) {
+      window.addEventListener('dragover', this.#onMouseMove);
+    }
+    document.body.appendChild(ghostRow);
+  };
+
+  #onMouseMove = (e: MouseEvent) => {
+    this.#mousePos.x = e.clientX;
+    this.#mousePos.y = e.clientY;
+  };
+
+  create: GhostRowCreate = ({
+    row,
+    startX,
+    startY,
+    className = '',
+    rowStyle = {},
+    cellStyle = {},
+    rowStylesToClone = [],
+    cellStylesToClone = [],
+  }) => {
+    if (!(row instanceof HTMLTableRowElement)) {
+      throw new Error('Invalid row element provided.');
+    }
+
+    const clonedRow = row.cloneNode(true) as HTMLTableRowElement;
+    this.#grabHandleOffset.x = row.offsetLeft + startX;
+    this.#grabHandleOffset.y = row.offsetHeight / 2;
+
+    this.#cloneRowStyles(row, clonedRow, rowStylesToClone);
+    this.#cloneCellStyles(row, clonedRow, cellStylesToClone);
+
+    this.#applyCustomStyles(clonedRow, rowStyle);
+    clonedRow.childNodes.forEach((cell) => {
+      this.#applyCustomStyles(cell as HTMLElement, cellStyle);
+    });
+
+    this.#addGhostClasses(clonedRow, className);
+    this.#addGhostStyles(clonedRow, startY, row.offsetWidth);
+
+    this.#addGhostRowToDom(clonedRow);
+    this.#ghostNode = clonedRow;
+  };
+
+  move = (posX: number, posY: number) => {
+    if (!this.#ghostNode) return;
+    const x = this.#isFirefox ? this.#mousePos.x : posX;
+    const y = this.#isFirefox ? this.#mousePos.y : posY;
+    const offsetX = x - this.#grabHandleOffset.x;
+    const offsetY = y - this.#grabHandleOffset.y;
+    this.#ghostNode.style.transform = `translate(${offsetX}px, ${offsetY}px)`;
+  };
+
+  remove() {
+    if (!this.#ghostNode) return;
+    this.#ghostNode.remove();
+    this.#ghostNode = null;
+    if (this.#isFirefox) {
+      window.removeEventListener('dragover', this.#onMouseMove);
+    }
+  }
+}

--- a/packages/mantine-react-table/src/body/MRT_TableBodyRowGrabHandle.tsx
+++ b/packages/mantine-react-table/src/body/MRT_TableBodyRowGrabHandle.tsx
@@ -1,6 +1,8 @@
-import { type DragEvent, type RefObject } from 'react';
+import { useRef, type DragEvent, type RefObject } from 'react';
 import { type MRT_Cell, type MRT_TableInstance } from '../types';
 import { MRT_GrabHandleButton } from '../buttons/MRT_GrabHandleButton';
+import { GhostRow } from '../GhostRow';
+import { useMantineTheme } from '@mantine/core';
 
 interface Props<TData extends Record<string, any>> {
   cell: MRT_Cell<TData>;
@@ -13,23 +15,58 @@ export const MRT_TableBodyRowGrabHandle = <TData extends Record<string, any>>({
   rowRef,
   table,
 }: Props<TData>) => {
+  const theme = useMantineTheme();
+  const ghostRowRef = useRef<GhostRow | null>(null);
+
   const {
     options: { mantineRowDragHandleProps },
   } = table;
   const { row } = cell;
 
-  const actionIconProps =
+  const { ghostRowProps, ...actionIconProps } =
     mantineRowDragHandleProps instanceof Function
       ? mantineRowDragHandleProps({ row, table })
-      : mantineRowDragHandleProps;
+      : mantineRowDragHandleProps ?? {};
 
   const handleDragStart = (event: DragEvent<HTMLButtonElement>) => {
     actionIconProps?.onDragStart?.(event);
-    event.dataTransfer.setDragImage(rowRef.current as HTMLElement, 0, 0);
+
+    if (ghostRowProps?.enabled) {
+      const ghostRow = GhostRow.getInstance();
+
+      const { enabled, rowStyle, cellStyle, ...otherGhostRowProps } =
+        ghostRowProps;
+      const ghostRowStyle =
+        rowStyle instanceof Function ? rowStyle({ theme }) : rowStyle ?? {};
+      const ghostCellStyle =
+        cellStyle instanceof Function ? cellStyle({ theme }) : cellStyle ?? {};
+      ghostRow.create({
+        row: rowRef.current as HTMLTableRowElement,
+        startX: event.clientX,
+        startY: event.clientY,
+        rowStyle: ghostRowStyle,
+        cellStyle: ghostCellStyle,
+        ...otherGhostRowProps,
+      });
+      ghostRowRef.current = ghostRow;
+    } else {
+      event.dataTransfer.setDragImage(rowRef.current as HTMLElement, 0, 0);
+    }
+
     table.setDraggingRow(row as any);
   };
 
+  const HandleDrag = (event: DragEvent<HTMLButtonElement>) => {
+    if (ghostRowProps?.enabled) {
+      ghostRowRef.current?.move(event.clientX, event.clientY);
+    }
+    actionIconProps?.onDrag?.(event);
+  };
+
   const handleDragEnd = (event: DragEvent<HTMLButtonElement>) => {
+    if (ghostRowProps?.enabled) {
+      ghostRowRef.current?.remove();
+    }
     actionIconProps?.onDragEnd?.(event);
     table.setDraggingRow(null);
     table.setHoveredRow(null);
@@ -39,6 +76,7 @@ export const MRT_TableBodyRowGrabHandle = <TData extends Record<string, any>>({
     <MRT_GrabHandleButton
       actionIconProps={actionIconProps}
       onDragStart={handleDragStart}
+      onDrag={HandleDrag}
       onDragEnd={handleDragEnd}
       table={table}
     />

--- a/packages/mantine-react-table/src/buttons/MRT_GrabHandleButton.tsx
+++ b/packages/mantine-react-table/src/buttons/MRT_GrabHandleButton.tsx
@@ -5,7 +5,7 @@ import { type HTMLPropsRef, type MRT_TableInstance } from '../types';
 interface Props<TData extends Record<string, any>> {
   actionIconProps?: ActionIconProps & HTMLPropsRef<HTMLButtonElement>;
   onDragStart: DragEventHandler<HTMLButtonElement>;
-  onDrag: DragEventHandler<HTMLButtonElement>;
+  onDrag?: DragEventHandler<HTMLButtonElement>;
   onDragEnd: DragEventHandler<HTMLButtonElement>;
   table: MRT_TableInstance<TData>;
 }

--- a/packages/mantine-react-table/src/buttons/MRT_GrabHandleButton.tsx
+++ b/packages/mantine-react-table/src/buttons/MRT_GrabHandleButton.tsx
@@ -5,6 +5,7 @@ import { type HTMLPropsRef, type MRT_TableInstance } from '../types';
 interface Props<TData extends Record<string, any>> {
   actionIconProps?: ActionIconProps & HTMLPropsRef<HTMLButtonElement>;
   onDragStart: DragEventHandler<HTMLButtonElement>;
+  onDrag: DragEventHandler<HTMLButtonElement>;
   onDragEnd: DragEventHandler<HTMLButtonElement>;
   table: MRT_TableInstance<TData>;
 }
@@ -12,6 +13,7 @@ interface Props<TData extends Record<string, any>> {
 export const MRT_GrabHandleButton = <TData extends Record<string, any>>({
   actionIconProps,
   onDragEnd,
+  onDrag,
   onDragStart,
   table,
 }: Props<TData>) => {
@@ -39,6 +41,7 @@ export const MRT_GrabHandleButton = <TData extends Record<string, any>>({
         }}
         onDragStart={onDragStart}
         onDragEnd={onDragEnd}
+        onDrag={onDrag}
         sx={(theme) => ({
           cursor: 'grab',
           margin: '0 -0.16px',

--- a/packages/mantine-react-table/src/types.ts
+++ b/packages/mantine-react-table/src/types.ts
@@ -63,6 +63,7 @@ import { type MRT_AggregationFns } from './aggregationFns';
 import { type MRT_FilterFns } from './filterFns';
 import { type MRT_SortingFns } from './sortingFns';
 import { type MRT_Icons } from './icons';
+import { type GhostRowProps } from './GhostRow';
 
 export type { MRT_Icons };
 
@@ -891,11 +892,17 @@ export type MRT_TableOptions<TData extends Record<string, any>> = Omit<
         table: MRT_TableInstance<TData>;
       }) => PaperProps & HTMLPropsRef<HTMLDivElement>);
   mantineRowDragHandleProps?:
-    | (HTMLPropsRef<HTMLButtonElement> & Partial<ActionIconProps>)
+    | (HTMLPropsRef<HTMLButtonElement> &
+        Partial<ActionIconProps> & {
+          ghostRowProps?: GhostRowProps;
+        })
     | ((props: {
         table: MRT_TableInstance<TData>;
         row: MRT_Row<TData>;
-      }) => HTMLPropsRef<HTMLButtonElement> & Partial<ActionIconProps>);
+      }) => HTMLPropsRef<HTMLButtonElement> &
+        Partial<ActionIconProps> & {
+          ghostRowProps?: GhostRowProps;
+        });
   mantineSearchTextInputProps?:
     | (HTMLPropsRef<HTMLInputElement> & Partial<TextInputProps>)
     | ((props: {

--- a/packages/mantine-react-table/stories/features/RowOrdering.stories.tsx
+++ b/packages/mantine-react-table/stories/features/RowOrdering.stories.tsx
@@ -81,6 +81,41 @@ export const RowOrderingEnabled = () => {
   );
 };
 
+export const RowOrderingGhostRow = () => {
+  const [data, setData] = useState(() => initData);
+
+  return (
+    <MantineReactTable
+      autoResetPageIndex={false}
+      columns={columns}
+      data={data}
+      enableRowOrdering
+      enableSorting={false}
+      mantineRowDragHandleProps={({ table }) => ({
+        onDragEnd: () => {
+          const { draggingRow, hoveredRow } = table.getState();
+          if (hoveredRow && draggingRow) {
+            data.splice(
+              (hoveredRow as MRT_Row<Person>).index,
+              0,
+              data.splice(draggingRow.index, 1)[0],
+            );
+            setData([...data]);
+          }
+        },
+        ghostRowProps: {
+          enabled: true,
+          rowStyle: ({ theme }) => ({
+            opacity: 0.9,
+            border: `1px solid ${theme.colors.blue[5]}`,
+            boxShadow: `0 0 30px 0 ${theme.colors.blue[5]}`,
+          }),
+        },
+      })}
+    />
+  );
+};
+
 export const RowOrderingWithSelect = () => {
   const [data, setData] = useState(() => initData);
   const [draggingRow, setDraggingRow] = useState<MRT_Row<Person> | null>(null);


### PR DESCRIPTION
**Description**

This PR introduces a solution to style a hover image that appears when dragging an element in one of my projects. The native drag-and-drop API does not provide built-in styling capabilities, so this implementation provides a simple solution to address this requirement.

**Changes Made**

- Added a GhostRow class that handles the creation and manipulation of the ghost row element used for styling during drag-and-drop.
- Implemented the create method to create a clone of the original row element and apply specified styles and classes.
- Implemented the move method to update the position of the ghost row element based on the mouse cursor's position.
- Added support for customizing row and cell styles through the rowStyle and cellStyle props.
- Introduced the rowStylesToClone and cellStylesToClone props to allow specifying additional CSS properties to be cloned from the original row and cell elements.
- Handled the case of Firefox not firing mousemove events during drag by adding a workaround using the dragover event.
- Handled cleanup in the remove method to remove the ghost row element and unregister event listeners.

These changes enable the desired styling of the hover element during drag-and-drop operations by providing an easy-to-use and customizable solution.