### PR TITLE
convert a couple sx to style as a test of pr process

### DIFF
--- a/packages/mantine-react-table/src/inputs/MRT_FilterCheckbox.tsx
+++ b/packages/mantine-react-table/src/inputs/MRT_FilterCheckbox.tsx
@@ -70,11 +70,13 @@ export const MRT_FilterCheckbox = <TData extends Record<string, any> = {}>({
           );
           checkboxProps?.onChange?.(e);
         }}
-        style={{
+        style={(theme) => ({
           fontWeight: 'normal',
           marginTop: '8px',
-          ...checkboxProps?.style,
-        }}
+          ...(checkboxProps?.style instanceof Function
+            ? checkboxProps.style(theme)
+            : (checkboxProps?.style as any)),
+        })}
         title={undefined}
       />
     </Tooltip>

--- a/packages/mantine-react-table/src/inputs/MRT_FilterCheckbox.tsx
+++ b/packages/mantine-react-table/src/inputs/MRT_FilterCheckbox.tsx
@@ -73,6 +73,7 @@ export const MRT_FilterCheckbox = <TData extends Record<string, any> = {}>({
         style={{
           fontWeight: 'normal',
           marginTop: '8px',
+          ...checkboxProps?.style,
         }}
         title={undefined}
       />

--- a/packages/mantine-react-table/src/inputs/MRT_FilterCheckbox.tsx
+++ b/packages/mantine-react-table/src/inputs/MRT_FilterCheckbox.tsx
@@ -70,13 +70,10 @@ export const MRT_FilterCheckbox = <TData extends Record<string, any> = {}>({
           );
           checkboxProps?.onChange?.(e);
         }}
-        sx={(theme) => ({
+        style={{
           fontWeight: 'normal',
           marginTop: '8px',
-          ...(checkboxProps?.sx instanceof Function
-            ? checkboxProps.sx(theme)
-            : (checkboxProps?.sx as any)),
-        })}
+        }}
         title={undefined}
       />
     </Tooltip>

--- a/packages/mantine-react-table/src/inputs/MRT_FilterRangeFields.tsx
+++ b/packages/mantine-react-table/src/inputs/MRT_FilterRangeFields.tsx
@@ -12,7 +12,9 @@ export const MRT_FilterRangeFields = <TData extends Record<string, any> = {}>({
   table,
 }: Props<TData>) => {
   return (
-    <Box sx={{ display: 'grid', gridTemplateColumns: '6fr 6fr', gap: '16px' }}>
+    <Box
+      style={{ display: 'grid', gridTemplateColumns: '6fr 6fr', gap: '16px' }}
+    >
       <MRT_FilterTextInput header={header} rangeFilterIndex={0} table={table} />
       <MRT_FilterTextInput header={header} rangeFilterIndex={1} table={table} />
     </Box>

--- a/packages/mantine-react-table/src/inputs/MRT_FilterRangeSlider.tsx
+++ b/packages/mantine-react-table/src/inputs/MRT_FilterRangeSlider.tsx
@@ -101,13 +101,15 @@ export const MRT_FilterRangeSlider = <TData extends Record<string, any> = {}>({
           }
         }
       }}
-      style={{
+      style={(theme) => ({
         margin: 'auto',
         marginTop: '16px',
         marginBottom: '6px',
         width: 'calc(100% - 8px)',
-        ...rangeSliderProps?.style,
-      }}
+        ...(rangeSliderProps?.style instanceof Function
+          ? rangeSliderProps.style(theme)
+          : (rangeSliderProps?.style as any)),
+      })}
     />
   );
 };

--- a/packages/mantine-react-table/src/inputs/MRT_FilterRangeSlider.tsx
+++ b/packages/mantine-react-table/src/inputs/MRT_FilterRangeSlider.tsx
@@ -106,6 +106,7 @@ export const MRT_FilterRangeSlider = <TData extends Record<string, any> = {}>({
         marginTop: '16px',
         marginBottom: '6px',
         width: 'calc(100% - 8px)',
+        ...rangeSliderProps?.style,
       }}
     />
   );

--- a/packages/mantine-react-table/src/inputs/MRT_FilterRangeSlider.tsx
+++ b/packages/mantine-react-table/src/inputs/MRT_FilterRangeSlider.tsx
@@ -101,15 +101,12 @@ export const MRT_FilterRangeSlider = <TData extends Record<string, any> = {}>({
           }
         }
       }}
-      sx={(theme) => ({
+      style={{
         margin: 'auto',
         marginTop: '16px',
         marginBottom: '6px',
         width: 'calc(100% - 8px)',
-        ...(rangeSliderProps?.sx instanceof Function
-          ? rangeSliderProps.sx(theme)
-          : (rangeSliderProps?.sx as any)),
-      })}
+      }}
     />
   );
 };


### PR DESCRIPTION
just checking the process here... if this is acceptable, i can go pick off some other sx -> style low hanging fruit.

noting that not only are we eliminating sx from internals, but removing it from the api so users of MRT will also have to convert to using css modules or pass style={{}}