### PR TITLE
refactor: column utils to CSS modules

### DIFF
--- a/packages/mantine-react-table/src/body/.MRT_TableBodyCell.module.css
+++ b/packages/mantine-react-table/src/body/.MRT_TableBodyCell.module.css
@@ -1,0 +1,17 @@
+.MRT_TableBodyCell {
+  align-items: var(--align-items);
+  cursor: var(--cursor);
+  justify-content: var(--align);
+  overflow: hidden;
+  padding-left: var(--padding-left);
+  white-space: var(--white-space);
+  z-index: var(--z-index);
+  :is([data-columndef="data"], [data-columndef="group"]) {
+    text-overflow: ellipsis;
+  }
+  @mixin hover {
+    outline: var(--outline);
+    outline-offset: -1px;
+    text-overflow: clip;
+  }
+}

--- a/packages/mantine-react-table/src/body/MRT_TableBodyCell.tsx
+++ b/packages/mantine-react-table/src/body/MRT_TableBodyCell.tsx
@@ -1,13 +1,14 @@
 import {
+  type DragEvent,
   memo,
+  type MouseEvent,
+  type RefObject,
   useEffect,
   useMemo,
   useState,
-  type DragEvent,
-  type MouseEvent,
-  type RefObject,
 } from 'react';
 import { Box, Skeleton, useMantineTheme } from '@mantine/core';
+import clsx from 'clsx';
 import { MRT_EditCellTextInput } from '../inputs/MRT_EditCellTextInput';
 import { MRT_CopyButton } from '../buttons/MRT_CopyButton';
 import { MRT_TableBodyCellValue } from './MRT_TableBodyCellValue';
@@ -15,13 +16,13 @@ import {
   getCommonCellStyles,
   getIsFirstColumn,
   getIsLastColumn,
-  getPrimaryColor,
 } from '../column.utils';
 import {
   type MRT_Cell,
   type MRT_TableInstance,
   type MRT_VirtualItem,
 } from '../types';
+import classes from './MRT_TableBodyRow.module.css';
 
 interface Props<TData extends Record<string, any> = {}> {
   cell: MRT_Cell<TData>;
@@ -122,9 +123,9 @@ export const MRT_TableBodyCell = <TData extends Record<string, any> = {}>({
 
     const borderStyle =
       isDraggingColumn || isDraggingRow
-        ? `1px dashed ${theme.colors.gray[7]} !important`
+        ? '1px dashed var(--mantine-color-gray-7) !important'
         : isHoveredColumn || isHoveredRow
-        ? `2px dashed ${getPrimaryColor(theme)} !important`
+        ? '2px dashed var(--mantine-primary-color-filled) !important'
         : undefined;
 
     return borderStyle
@@ -193,53 +194,65 @@ export const MRT_TableBodyCell = <TData extends Record<string, any> = {}>({
     }
   };
 
+  const { style, className, __vars } = getCommonCellStyles({
+    column,
+    isStriped,
+    row,
+    table,
+    theme,
+    tableCellProps,
+  });
+
   return (
     <Box
       component="td"
       data-index={virtualCell?.index}
+      data-selected={row?.getIsSelected() ?? 'false'}
+      data-ispinned={column?.getIsPinned() ?? 'false'}
+      data-striped={isStriped}
+      data-columndef={columnDefType}
       ref={(node: HTMLTableCellElement) => {
         if (node) {
           measureElement?.(node);
         }
       }}
       {...tableCellProps}
-      onDragEnter={handleDragEnter}
-      onDoubleClick={handleDoubleClick}
-      style={(theme) => ({
-        alignItems: layoutMode === 'grid' ? 'center' : undefined,
-        cursor:
+      __vars={{
+        ...__vars,
+        '--align-items': layoutMode === 'grid' ? 'center' : undefined,
+        '--cursor':
           isEditable && editDisplayMode === 'cell' ? 'pointer' : 'inherit',
-        justifyContent:
-          layoutMode === 'grid' ? tableCellProps.align : undefined,
-        overflow: 'hidden',
-        paddingLeft:
+        '--align': layoutMode === 'grid' ? tableCellProps.align : undefined,
+        '--padding-left':
           column.id === 'mrt-row-expand'
             ? `${row.depth + 1}rem !important`
             : undefined,
-        textOverflow: columnDefType !== 'display' ? 'ellipsis' : undefined,
-        whiteSpace: density === 'xs' ? 'nowrap' : 'normal',
-        zIndex:
-          draggingColumn?.id === column.id ? 2 : column.getIsPinned() ? 1 : 0,
-        '&:hover': {
-          outline:
-            isEditing &&
-            ['table', 'cell'].includes(editDisplayMode ?? '') &&
-            columnDefType !== 'display'
-              ? `1px solid ${theme.colors.gray[7]}`
-              : undefined,
-          outlineOffset: '-1px',
-          textOverflow: 'clip',
-        },
-        ...getCommonCellStyles({
-          column,
-          isStriped,
-          row,
-          table,
-          theme,
-          tableCellProps,
-        }),
+        '--white-space': density === 'xs' ? 'nowrap' : 'normal',
+        '--z-index':
+          draggingColumn?.id === column.id
+            ? 2
+            : column.getIsPinned()
+            ? '1'
+            : '0',
+        '--outline':
+          isEditing &&
+          ['table', 'cell'].includes(editDisplayMode ?? '') &&
+          columnDefType !== 'display'
+            ? `1px solid var(--mantine-color-gray-7)`
+            : undefined,
+        ...tableCellProps.__vars,
+      }}
+      className={clsx(
+        className,
+        classes.MRT_TableBodyCell,
+        tableCellProps.className,
+      )}
+      onDragEnter={handleDragEnter}
+      onDoubleClick={handleDoubleClick}
+      style={{
+        ...style,
         ...draggingBorders,
-      })}
+      }}
     >
       <>
         {cell.getIsPlaceholder() ? (

--- a/packages/mantine-react-table/src/body/MRT_TableHeadCell.module.css
+++ b/packages/mantine-react-table/src/body/MRT_TableHeadCell.module.css
@@ -1,0 +1,14 @@
+.MRT_TableHeadCell {
+  flex-direction: var(--flex-direction);
+  font-weight: bold;
+  overflow: visible;
+  padding: rem(var(--padding));
+  user-select: var(--user-select);
+  vertical-align: top;
+  z-index: var(--z-index);
+  @mixin hover {
+    .mantine-ActionIcon-root {
+      opacity: 1;
+    }
+  }
+}

--- a/packages/mantine-react-table/src/columns.utils.module.css
+++ b/packages/mantine-react-table/src/columns.utils.module.css
@@ -1,0 +1,47 @@
+.MRT_Column-common-styles {
+  --min-width: max(calc(var(--header-id) * 1px), var(--col-size));
+  --width: calc(var(--header-id) * 1px);
+  --bg-color: color-mix(in srgb, var(--mantine-color-dark-7) .2%, var(--mantine-color-black));
+  background-color: inherit;
+  // Not very sure about these attribute gymnastics...
+  [data-selected="true"] {
+      background-color: rgba(var(--mantine-primary-color-filled), 0.1);
+  }
+  :is([data-ispinned="left"], [data-ispinned="right"])[data-selected="false"][data-columndef="group"] {
+      @mixin light {
+        background-color: rgba(var(--mantine-color-white), 0.97);
+      }
+      @mixin dark {
+        --bg-color: color-mix(in srgb, var(--mantine-color-dark-7) .2%, var(--mantine-color-black));
+        background-color: rgba(var(--bg-color) ,0.97);
+      }
+  }
+  [data-striped="true"][data-selected="false"][data-ispinned="false"] {
+    background-color: inherit;
+  }
+  [data-striped="true"][data-selected="false"][data-ispinned="false"] {
+    @mixin light {
+      background-color: var(--mantine-color-white);
+    }
+    @mixin dark {
+      background-color: rgba(var(--bg-color) ,0.97);
+    }
+  }
+  [data-ispinned="left"] {
+    left: var(--left);
+  }
+  :is([data-ispinned="left"], [data-ispinned="right"])[data-columndef="group"] {
+    position: sticky;
+  }
+  [data-ispinned="right"]{
+    right: var(--right);
+  }
+  margin-left: var(--ml);
+  margin-right: var(--mr);
+  background-clip: padding-box;
+  display: var(--display);
+  box-shadow: var(--box-shadow);
+  flex: var(--flex);
+  opacity: var(--opacity);
+  transition: var(--transition);
+}

--- a/packages/mantine-react-table/src/footer/MRT_TableFooterCell.module.css
+++ b/packages/mantine-react-table/src/footer/MRT_TableFooterCell.module.css
@@ -1,18 +1,11 @@
 .MRT_TableFooterCell {
   font-weight: bold;
-  // Not resolved?
   padding: rem(9px);
   vertical-align: top;
+  z-index: var(--z-index);
+  display: var(--display);
 
-  &--center-column {
+  [data-columndef="group"] {
     justify-content: center;
-  }
-
-  &--grid {
-    display: grid;
-  }
-
-  &--table-cell {
-    display: table-cell;
   }
 }

--- a/packages/mantine-react-table/src/footer/MRT_TableFooterCell.tsx
+++ b/packages/mantine-react-table/src/footer/MRT_TableFooterCell.tsx
@@ -35,29 +35,35 @@ export const MRT_TableFooterCell = <TData extends Record<string, any> = {}>({
     ...mcTableFooterCellProps,
   };
 
+  const {
+    className: commonClassName,
+    __vars,
+    style,
+  } = getCommonCellStyles({
+    column,
+    table,
+    theme,
+    tableCellProps,
+  });
+
   return (
     <Box
       component="th"
       align={columnDefType === 'group' ? 'center' : 'left'}
       colSpan={footer.colSpan}
+      data-selected={row?.getIsSelected() ?? 'false'}
+      data-ispinned={column?.getIsPinned() ?? 'false'}
+      data-columndef={columnDefType}
       {...tableCellProps}
-      className={clsx(
-        classes.MRT_TableFooterCell,
-        layoutMode === 'grid'
-          ? classes.MRT_TableFooterCellGrid
-          : classes.MRT_TableFooterCellTableCell,
-        columnDefType === 'group' && classes.MRT_TableFooterCellCenterColumn,
-        className,
-      )}
-      style={(theme) => ({
-        zIndex: column.getIsPinned() && columnDefType !== 'group' ? 2 : 1,
-        ...getCommonCellStyles({
-          column,
-          table,
-          theme,
-          tableCellProps,
-        }),
-      })}
+      className={clsx(commonClassName, classes.MRT_TableFooterCell, className)}
+      __vars={{
+        ...__vars,
+        '--z-index':
+          column.getIsPinned() && columnDefType !== 'group' ? '2' : '1',
+        '--display': layoutMode === 'grid' ? 'grid' : 'table-cell',
+        ...tableCellProps.__vars,
+      }}
+      style={style}
     >
       <>
         {footer.isPlaceholder

--- a/packages/mantine-react-table/src/head/MRT_TableHeadCell.tsx
+++ b/packages/mantine-react-table/src/head/MRT_TableHeadCell.tsx
@@ -1,12 +1,13 @@
 import { type DragEvent, type ReactNode, useMemo } from 'react';
 import { Box, Flex, type MantineTheme, useMantineTheme } from '@mantine/core';
+import clsx from 'clsx';
 import { MRT_ColumnActionMenu } from '../menus/MRT_ColumnActionMenu';
 import { MRT_TableHeadCellFilterContainer } from './MRT_TableHeadCellFilterContainer';
 import { MRT_TableHeadCellFilterLabel } from './MRT_TableHeadCellFilterLabel';
 import { MRT_TableHeadCellGrabHandle } from './MRT_TableHeadCellGrabHandle';
 import { MRT_TableHeadCellResizeHandle } from './MRT_TableHeadCellResizeHandle';
 import { MRT_TableHeadCellSortLabel } from './MRT_TableHeadCellSortLabel';
-import { getCommonCellStyles, getPrimaryColor } from '../column.utils';
+import { getCommonCellStyles } from '../column.utils';
 import { type MRT_Header, type MRT_TableInstance } from '../types';
 
 import classes from './MRT_TableHeadCell.module.css';
@@ -80,9 +81,9 @@ export const MRT_TableHeadCell = <TData extends Record<string, any> = {}>({
   const draggingBorder = useMemo(
     () =>
       draggingColumn?.id === column.id
-        ? `1px dashed ${theme.colors.gray[7]} !important`
+        ? `1px dashed var(--mantine-color-gray-7) !important`
         : hoveredColumn?.id === column.id
-        ? `2px dashed ${getPrimaryColor(theme)} !important`
+        ? `2px dashed var(--mantine-color-gray-7) !important`
         : undefined,
     [draggingColumn, hoveredColumn],
   );
@@ -114,44 +115,55 @@ export const MRT_TableHeadCell = <TData extends Record<string, any> = {}>({
           table,
         })
       : columnDef?.Header ?? (columnDef.header as ReactNode);
+  const { className, __vars, style } = getCommonCellStyles({
+    column,
+    header,
+    table,
+    tableCellProps,
+    theme,
+  });
 
   return (
     <Box
       component="th"
       align={columnDefType === 'group' ? 'center' : 'left'}
+      data-selected={row?.getIsSelected() ?? 'false'}
+      data-ispinned={column?.getIsPinned() ?? 'false'}
+      data-cansort={column.getCanSort()}
+      data-isresizing={column.getIsResizing()}
       colSpan={header.colSpan}
       onDragEnter={handleDragEnter}
+      data-columndef={columnDefType}
       ref={(node: HTMLTableCellElement) => {
         if (node) {
           tableHeadCellRefs.current[column.id] = node;
         }
       }}
       {...tableCellProps}
-      style={(theme: MantineTheme) => ({
-        flexDirection: layoutMode === 'grid' ? 'column' : undefined,
-        fontWeight: 'bold',
-        overflow: 'visible',
-        padding: density === 'xl' ? '23px' : density === 'md' ? '16px' : '10px',
-        userSelect: enableMultiSort && column.getCanSort() ? 'none' : undefined,
-        verticalAlign: 'top',
-        zIndex:
+      className={clsx(
+        className,
+        classes.MRT_TableHeadCell,
+        tableCellProps.className,
+      )}
+      __vars={{
+        ...__vars,
+        '--flex-direction': layoutMode === 'grid' ? 'column' : undefined,
+        '--padding':
+          density === 'xl' ? '23px' : density === 'md' ? '16px' : '10px',
+        '--user-select':
+          enableMultiSort && column.getCanSort() ? 'none' : undefined,
+        '--z-index':
           column.getIsResizing() || draggingColumn?.id === column.id
-            ? 3
+            ? '3'
             : column.getIsPinned() && columnDefType !== 'group'
-            ? 2
-            : 1,
-        '&:hover .mantine-ActionIcon-root': {
-          opacity: 1,
-        },
-        ...getCommonCellStyles({
-          column,
-          header,
-          table,
-          tableCellProps,
-          theme,
-        }),
+            ? '2'
+            : '1',
+        ...tableCellProps.__vars,
+      }}
+      style={{
+        ...style,
         ...draggingBorders,
-      })}
+      }}
     >
       {header.isPlaceholder ? null : (
         <Flex


### PR DESCRIPTION
`getCommonCellStyles` has been refactored and now returns:
* `className`: the CSS class that applies the common styles
* `__vars`: a CSS variable definition function for the above `className`
* `style`: applies the style overrides passed by the user
Please let me know if this API is not ideal. I would also like some feedback on the approach with data attributes for the `common.moule.css` file, not very sure about that.

Additionally a few helper function have been removed and replaced with Mantine v7 new CSS variables, I think further optimizations can be made here but I tried to scope this commit to only fix breaking changes.
