### PR TITLE
Fix undefined values with loading states

### DIFF
--- a/packages/mantine-react-table/src/body/MRT_TableBodyCell.tsx
+++ b/packages/mantine-react-table/src/body/MRT_TableBodyCell.tsx
@@ -250,8 +250,7 @@ export const MRT_TableBodyCell = <TData extends Record<string, any> = {}>({
       <>
         {cell.getIsPlaceholder() ? (
           columnDef.PlaceholderCell?.({ cell, column, row, table }) ?? null
-        ) : (isLoading || showSkeletons) &&
-          [undefined, null].includes(cell.getValue<any>()) ? (
+        ) : isLoading || showSkeletons ? (
           <Skeleton height={20} width={skeletonWidth} {...skeletonProps} />
         ) : enableRowNumbers &&
           rowNumberMode === 'static' &&


### PR DESCRIPTION
I have an issue where the skeleton for a cell wouldn't appear with `isLoading` set to `true` when using the `accessorFn`.
I noticed that this was also an issue in `material-react-table` ([713](https://github.com/KevinVandy/material-react-table/issues/713), [721](https://github.com/KevinVandy/material-react-table/issues/721)) so I implemented the same fix here.