### PR TITLE
Add mantinePaperFullscreenStyles table option

### DIFF
--- a/apps/mantine-react-table-docs/components/prop-tables/tableOptions.ts
+++ b/apps/mantine-react-table-docs/components/prop-tables/tableOptions.ts
@@ -1401,6 +1401,17 @@ export const tableOptions: TableOption[] = [
     type: 'PaperProps | ({ table }} => PaperProps',
   },
   {
+    tableOption: 'mantinePaperFullscreenStyles',
+    defaultValue: '',
+    description:
+      'Additional Styles to add to the Mantine Paper component when in full screen mode',
+    link: 'https://mantine.dev/core/paper/?t=props',
+    linkText: 'Mantine Paper Docs',
+    required: false,
+    source: 'Mantine',
+    type: 'React.CSSProperties | undefined',
+  },
+  {
     tableOption: 'mantineTableProps',
     defaultValue: '',
     description: '',

--- a/apps/mantine-react-table-docs/pages/docs/guides/full-screen-toggle.mdx
+++ b/apps/mantine-react-table-docs/pages/docs/guides/full-screen-toggle.mdx
@@ -15,7 +15,13 @@ import StateOptionsTable from '../../../components/prop-tables/StateOptionsTable
 ### Relevant Table Options
 
 <TableOptionsTable
-  onlyOptions={new Set(['enableFullScreenToggle', 'onIsFullScreenChange'])}
+  onlyOptions={
+    new Set([
+      'enableFullScreenToggle',
+      'onIsFullScreenChange',
+      'mantinePaperFullscreenStyles',
+    ])
+  }
 />
 
 ### Relevant State
@@ -31,5 +37,23 @@ const table = useMantineReactTable({
   columns,
   data,
   enableFullScreenToggle: false,
+});
+```
+
+### Tweaking Full Screen Toggle Button Styles
+
+Use the `mantinePaperFullscreenStyles` table option to tweak the styles of the full screen toggle button.
+These props are passed to the `style` prop of the `MantinePaper` component that wraps the full Paper component.
+
+This example allows room for a sidebar on the right side of the screen.
+
+```jsx
+const table = useMantineReactTable({
+  columns,
+  data,
+  mantinePaperFullscreenStyles: {
+    width: 'auto',
+    inset: '0px 120px 0px 0px',
+  },
 });
 ```

--- a/packages/mantine-react-table/src/table/MRT_TablePaper.tsx
+++ b/packages/mantine-react-table/src/table/MRT_TablePaper.tsx
@@ -35,8 +35,6 @@ export const MRT_TablePaper = <TData extends Record<string, any> = {}>({
       ? mantinePaperFullscreenStyles({ table })
       : mantinePaperFullscreenStyles;
 
-  console.log('MRT_TablePaper', tablePaperFullScreenStyles);
-
   return (
     <Paper
       shadow="xs"

--- a/packages/mantine-react-table/src/table/MRT_TablePaper.tsx
+++ b/packages/mantine-react-table/src/table/MRT_TablePaper.tsx
@@ -17,6 +17,7 @@ export const MRT_TablePaper = <TData extends Record<string, any> = {}>({
       enableBottomToolbar,
       enableTopToolbar,
       mantinePaperProps,
+      mantinePaperFullscreenStyles,
       renderBottomToolbar,
       renderTopToolbar,
     },
@@ -28,6 +29,13 @@ export const MRT_TablePaper = <TData extends Record<string, any> = {}>({
     mantinePaperProps instanceof Function
       ? mantinePaperProps({ table })
       : mantinePaperProps;
+
+  const tablePaperFullScreenStyles =
+    mantinePaperFullscreenStyles instanceof Function
+      ? mantinePaperFullscreenStyles({ table })
+      : mantinePaperFullscreenStyles;
+
+  console.log('MRT_TablePaper', tablePaperFullScreenStyles);
 
   return (
     <Paper
@@ -62,6 +70,7 @@ export const MRT_TablePaper = <TData extends Record<string, any> = {}>({
               top: 0,
               width: '100vw',
               zIndex: 100,
+              ...tablePaperFullScreenStyles,
             }
           : {}),
         ...tablePaperProps?.style,

--- a/packages/mantine-react-table/src/types.ts
+++ b/packages/mantine-react-table/src/types.ts
@@ -925,6 +925,9 @@ export type MRT_TableOptions<TData extends Record<string, any> = {}> = Omit<
     | ((props: {
         table: MRT_TableInstance<TData>;
       }) => HTMLPropsRef<HTMLDivElement> & PaperProps);
+  mantinePaperFullscreenStyles?:
+    | React.CSSProperties
+    | ((props: { table: MRT_TableInstance<TData> }) => React.CSSProperties);
   mantineRowDragHandleProps?:
     | (HTMLPropsRef<HTMLButtonElement> & Partial<ActionIconProps>)
     | ((props: {

--- a/packages/mantine-react-table/stories/features/FullScreen.stories.tsx
+++ b/packages/mantine-react-table/stories/features/FullScreen.stories.tsx
@@ -94,3 +94,14 @@ export const ControlledFullScreen = () => {
     />
   );
 };
+
+export const FullScreenWithCustomStyles = () => (
+  <MantineReactTable
+    columns={columns}
+    data={data}
+    mantinePaperFullscreenStyles={{
+      width: 'auto',
+      inset: '0px 120px 0px 0px',
+    }}
+  />
+);


### PR DESCRIPTION
Hey :)

Thanks for the awesome library 

I thought this might be a useful escape hatch for full screen display in the event that theres a sidebar.

Apologies if my CSS example is dodgy.

- adds `mantinePaperFullscreenStyles` prop to the table options as `React.CSSProperties` (or a func returning this)
- adds documentation
- adds an example to stories
- applies the styles to the paper component when in full screen mode

Hope this is useful 

B
