### PR TITLE
Add CSS class to target full Screen mode

### DIFF
--- a/packages/mantine-react-table/src/table/MRT_TablePaper.tsx
+++ b/packages/mantine-react-table/src/table/MRT_TablePaper.tsx
@@ -38,6 +38,7 @@ export const MRT_TablePaper = <TData extends Record<string, any> = {}>({
       className={clsx(
         'mrt-table-paper',
         classes.root,
+        isFullScreen && 'mrt-table-paper-fullscreen',
         tablePaperProps?.className,
       )}
       ref={(ref: HTMLDivElement) => {


### PR DESCRIPTION
Enable developers to target the table in full-screen mode.

One example usage of this is when wanting to further control the full-screen z-index globally. In a micro front-end setup, we want to make sure all data grids have proper z-index when in full-screen mode.