### PR TITLE
Regression from v1 - Fix filter icon glitch

### DIFF
--- a/packages/mantine-react-table/src/head/MRT_TableHeadCellFilterLabel.tsx
+++ b/packages/mantine-react-table/src/head/MRT_TableHeadCellFilterLabel.tsx
@@ -71,70 +71,72 @@ export const MRT_TableHeadCellFilterLabel = <
           .replace('" "', '');
 
   return (
-    <Popover
-      onClose={() => setPopoverOpened(false)}
-      opened={popoverOpened}
-      position="top"
-      keepMounted={columnDef.filterVariant === 'range-slider'}
-      shadow="xl"
-      width={360}
-      withinPortal
-    >
-      <Transition
-        transition="scale"
-        mounted={
-          columnFilterDisplayMode === 'popover' ||
-          (!!column.getFilterValue() && !isRangeFilter) ||
-          (isRangeFilter && // @ts-ignore
-            (!!column.getFilterValue()?.[0] || !!column.getFilterValue()?.[1]))
-        }
+    <>
+      <Popover
+        onClose={() => setPopoverOpened(false)}
+        opened={popoverOpened}
+        position="top"
+        keepMounted={columnDef.filterVariant === 'range-slider'}
+        shadow="xl"
+        width={360}
+        withinPortal
       >
-        {() => (
-          <Popover.Target>
-            <Tooltip
-              disabled={popoverOpened}
-              label={filterTooltip}
-              multiline
-              w={filterTooltip.length > 40 ? 300 : undefined}
-              withinPortal
-            >
-              <ActionIcon
-                className={clsx(
-                  'mrt-table-head-cell-filter-label-icon',
-                  classes.root,
-                )}
-                size={18}
-                {...dataVariable('active', isFilterActive)}
-                onClick={(event: MouseEvent<HTMLButtonElement>) => {
-                  event.stopPropagation();
-                  if (columnFilterDisplayMode === 'popover') {
-                    setPopoverOpened((opened) => !opened);
-                  } else {
-                    setShowColumnFilters(true);
-                  }
-                  setTimeout(() => {
-                    const input = filterInputRefs.current[`${column.id}-0`];
-                    input?.focus();
-                    input?.select();
-                  }, 100);
-                }}
-              >
-                <IconFilter />
-              </ActionIcon>
-            </Tooltip>
-          </Popover.Target>
-        )}
-      </Transition>
-      {columnFilterDisplayMode === 'popover' && (
-        <Popover.Dropdown
-          onClick={(event) => event.stopPropagation()}
-          onKeyDown={(event) =>
-            event.key === 'Enter' && setPopoverOpened(false)
+        <Transition
+          transition="scale"
+          mounted={
+            columnFilterDisplayMode === 'popover' ||
+            (!!column.getFilterValue() && !isRangeFilter) ||
+            (isRangeFilter && // @ts-ignore
+              (!!column.getFilterValue()?.[0] || !!column.getFilterValue()?.[1]))
           }
         >
-          <MRT_TableHeadCellFilterContainer header={header} table={table} />
-        </Popover.Dropdown>
-      )}
-    </Popover>
+          {() => (
+            <Popover.Target>
+              <Tooltip
+                disabled={popoverOpened}
+                label={filterTooltip}
+                multiline
+                w={filterTooltip.length > 40 ? 300 : undefined}
+                withinPortal
+              >
+                <ActionIcon
+                  className={clsx(
+                    'mrt-table-head-cell-filter-label-icon',
+                    classes.root,
+                  )}
+                  size={18}
+                  {...dataVariable('active', isFilterActive)}
+                  onClick={(event: MouseEvent<HTMLButtonElement>) => {
+                    event.stopPropagation();
+                    if (columnFilterDisplayMode === 'popover') {
+                      setPopoverOpened((opened) => !opened);
+                    } else {
+                      setShowColumnFilters(true);
+                    }
+                    setTimeout(() => {
+                      const input = filterInputRefs.current[`${column.id}-0`];
+                      input?.focus();
+                      input?.select();
+                    }, 100);
+                  }}
+                >
+                  <IconFilter />
+                </ActionIcon>
+              </Tooltip>
+            </Popover.Target>
+          )}
+        </Transition>
+        {columnFilterDisplayMode === 'popover' && (
+          <Popover.Dropdown
+            onClick={(event) => event.stopPropagation()}
+            onKeyDown={(event) =>
+              event.key === 'Enter' && setPopoverOpened(false)
+            }
+          >
+            <MRT_TableHeadCellFilterContainer header={header} table={table} />
+          </Popover.Dropdown>
+        )}
+      </Popover>
+    </>
   );
 };


### PR DESCRIPTION
The current implementation is adding a span wrapper. Adding <></> remove the wrapper which makes the icon align properly.

Before (look at how the inputs are unaligned)
<img width="1761" alt="Screenshot 2023-11-28 at 11 46 32 AM" src="https://github.com/KevinVandy/mantine-react-table/assets/114950/1bd0a109-5a51-4cd5-8d1d-d1962d95a7aa">


After

<img width="1258" alt="Screenshot 2023-11-28 at 11 46 11 AM" src="https://github.com/KevinVandy/mantine-react-table/assets/114950/3b51c46d-8583-4891-90d6-faa67a46af95">
<img width="1644" alt="Screenshot 2023-11-28 at 11 46 16 AM" src="https://github.com/KevinVandy/mantine-react-table/assets/114950/f896a218-3f50-4c51-81c4-88696d8d552e">
