### PR TITLE
Set default spacing prop for input filters

### DIFF
--- a/packages/mantine-react-table/src/inputs/MRT_FilterTextInput.tsx
+++ b/packages/mantine-react-table/src/inputs/MRT_FilterTextInput.tsx
@@ -376,6 +376,7 @@ export const MRT_FilterTextInput = <TData extends Record<string, any> = {}>({
       onChange={(e) => setFilterValue(e.target.value)}
       {...textInputProps}
       className={clsx(className, textInputProps.className)}
+      mt={0}
       ref={(node) => {
         if (node) {
           filterInputRefs.current[`${column.id}-${rangeFilterIndex ?? 0}`] =

--- a/packages/mantine-react-table/src/inputs/MRT_GlobalFilterTextInput.tsx
+++ b/packages/mantine-react-table/src/inputs/MRT_GlobalFilterTextInput.tsx
@@ -85,6 +85,7 @@ export const MRT_GlobalFilterTextInput = <
         onChange={(event) => setSearchValue(event.target.value)}
         value={searchValue ?? ''}
         variant="filled"
+        mt={0}
         leftSection={!enableGlobalFilterModes && <IconSearch />}
         rightSection={
           searchValue ? (


### PR DESCRIPTION
With Mantine V7 you can now set default props on components globally using the theme provider, this creates a small challenge, especially around form inputs since the default mantine spacing is set to 0, there is a strong incentive to make forms look rights from the start leveraging the theme provider.

Example:

```
TextInput.extend({
    defaultProps: { mt: "sm" },
)}
```


In this PR I jut set the mt prop to 0 which is the wanted behavior in Search and Filter Text Input.