### PR TITLE
fix select and multi-select column filter selection

### DIFF
--- a/packages/mantine-react-table/src/inputs/MRT_FilterTextInput.tsx
+++ b/packages/mantine-react-table/src/inputs/MRT_FilterTextInput.tsx
@@ -251,8 +251,6 @@ export const MRT_FilterTextInput = <TData extends Record<string, any> = {}>({
     </ActionIcon>
   ) : null;
 
-  console.log(multiSelectProps)
-
   return filterChipLabel ? (
     <Box style={commonProps.style}>
       <Badge

--- a/packages/mantine-react-table/src/inputs/MRT_FilterTextInput.tsx
+++ b/packages/mantine-react-table/src/inputs/MRT_FilterTextInput.tsx
@@ -272,6 +272,8 @@ export const MRT_FilterTextInput = <TData extends Record<string, any> = {}>({
     </ActionIcon>
   ) : null;
 
+  console.log(multiSelectProps)
+
   return filterChipLabel ? (
     <Box style={commonProps.style}>
       <Badge
@@ -288,6 +290,7 @@ export const MRT_FilterTextInput = <TData extends Record<string, any> = {}>({
       {...commonProps}
       searchable
       {...multiSelectProps}
+      onChange={(value) => setFilterValue(value)}
       className={clsx(className, multiSelectProps.className)}
       data={filterSelectOptions}
       ref={(node) => {
@@ -300,17 +303,13 @@ export const MRT_FilterTextInput = <TData extends Record<string, any> = {}>({
         }
       }}
       style={commonProps.style}
-      rightSection={
-        <SelectClearButton
-          value={multiSelectProps.value}
-          onChange={multiSelectProps.onChange!}
-        />
-      }
+      rightSection={filterValue?.toString()?.length ? ClearButton : undefined}
     />
   ) : isSelectFilter ? (
     <Select
       {...commonProps}
       searchable
+      clearable
       {...selectProps}
       className={clsx(className, selectProps.className)}
       data={filterSelectOptions}
@@ -323,13 +322,6 @@ export const MRT_FilterTextInput = <TData extends Record<string, any> = {}>({
           }
         }
       }}
-      style={commonProps.style}
-      rightSection={
-        <SelectClearButton
-          value={multiSelectProps.value}
-          onChange={multiSelectProps.onChange!}
-        />
-      }
     />
   ) : isDateFilter ? (
     <DateInput

--- a/packages/mantine-react-table/src/inputs/MRT_FilterTextInput.tsx
+++ b/packages/mantine-react-table/src/inputs/MRT_FilterTextInput.tsx
@@ -5,8 +5,6 @@ import {
   Autocomplete,
   Badge,
   Box,
-  CloseButton,
-  Combobox,
   MultiSelect,
   Select,
   TextInput,
@@ -24,25 +22,6 @@ interface Props<TData extends Record<string, any> = {}> {
   rangeFilterIndex?: number;
   table: MRT_TableInstance<TData>;
 }
-
-const SelectClearButton = ({
-  value,
-  onChange,
-}: {
-  value: unknown;
-  onChange: (value: any) => void;
-}) => {
-  return value !== null ? (
-    <CloseButton
-      size="sm"
-      onMouseDown={(event) => event.preventDefault()}
-      onClick={() => onChange(null)}
-      aria-label="Clear value"
-    />
-  ) : (
-    <Combobox.Chevron />
-  );
-};
 
 export const MRT_FilterTextInput = <TData extends Record<string, any> = {}>({
   header,
@@ -313,6 +292,7 @@ export const MRT_FilterTextInput = <TData extends Record<string, any> = {}>({
       {...selectProps}
       className={clsx(className, selectProps.className)}
       data={filterSelectOptions}
+      style={commonProps.style}
       ref={(node) => {
         if (node) {
           filterInputRefs.current[`${column.id}-${rangeFilterIndex ?? 0}`] =


### PR DESCRIPTION
This PR fix:

* Correct Icon is displayed instead of an X when no values is selected
* Able to clear select and multi-select filter

Largely based on V1. https://github.com/KevinVandy/mantine-react-table/blob/v1/packages/mantine-react-table/src/inputs/MRT_FilterTextInput.tsx#L366

The largest change was removing the custom multi-select clear button, it works without it.

Before:
https://app.screencast.com/Sa8g9SABGuk9r


After:
https://app.screencast.com/xmv0bHEscmR8Y


