### PR TITLE
Fixes #204

### DIFF
--- a/packages/mantine-react-table/src/inputs/MRT_FilterTextInput.module.css
+++ b/packages/mantine-react-table/src/inputs/MRT_FilterTextInput.module.css
@@ -1,4 +1,5 @@
 .root {
+  font-weight: normal;
   border-bottom: 2px solid
     light-dark(var(--mantine-color-gray-3), var(--mantine-color-gray-7));
   min-width: auto;


### PR DESCRIPTION
Setting font-weight to normal for `MRT_FilterTextInput`

![image](https://github.com/KevinVandy/mantine-react-table/assets/84348947/db610f1a-db37-4259-aaf1-8d5e7f05ad5d)
