### PR TITLE
Fix indeterminate checkbox color

### DIFF
--- a/packages/mantine-react-table/src/inputs/MRT_FilterCheckbox.tsx
+++ b/packages/mantine-react-table/src/inputs/MRT_FilterCheckbox.tsx
@@ -45,7 +45,6 @@ export const MRT_FilterCheckbox = <TData extends Record<string, any> = {}>({
         className={clsx('mrt-filter-checkbox', classes.root)}
         checked={value === 'true'}
         indeterminate={value === undefined}
-        color={value === undefined ? 'default' : 'primary'}
         size={density === 'xs' ? 'sm' : 'md'}
         label={checkboxProps.title ?? filterLabel}
         {...checkboxProps}


### PR DESCRIPTION
Fixes #202 

Mantine [v6](https://v6.mantine.dev/core/checkbox/#states) used to have an indeterminate default checkbox state which isn't present in [v7](https://mantine.dev/core/checkbox/#states).

The MRT_FilterCheckbox should now use the primary color or the color passed by the user through `mantineFilterCheckboxProps` prop.

![image](https://github.com/KevinVandy/mantine-react-table/assets/84348947/d9328249-9c0e-4bdc-8252-6661417fadbd)
