### PR TITLE
Fix inconsistent Buttons hover and clear buttons size

### DIFF
--- a/packages/mantine-react-table/src/buttons/MRT_ExpandAllButton.tsx
+++ b/packages/mantine-react-table/src/buttons/MRT_ExpandAllButton.tsx
@@ -46,7 +46,7 @@ export const MRT_ExpandAllButton = <TData extends Record<string, any> = {}>({
       <ActionIcon
         aria-label={localization.expandAll}
         color="gray"
-        variant="transparent"
+        variant="subtle"
         {...actionIconProps}
         disabled={isLoading || (!renderDetailPanel && !getCanSomeRowsExpand())}
         onClick={() => toggleAllRowsExpanded(!isAllRowsExpanded)}

--- a/packages/mantine-react-table/src/buttons/MRT_ExpandButton.tsx
+++ b/packages/mantine-react-table/src/buttons/MRT_ExpandButton.tsx
@@ -52,7 +52,7 @@ export const MRT_ExpandButton = <TData extends Record<string, any> = {}>({
         aria-label={localization.expand}
         color="gray"
         disabled={!canExpand && !renderDetailPanel}
-        variant="transparent"
+        variant="subtle"
         {...actionIconProps}
         onClick={handleToggleExpand}
         className={clsx(

--- a/packages/mantine-react-table/src/buttons/MRT_RowPinButton.tsx
+++ b/packages/mantine-react-table/src/buttons/MRT_RowPinButton.tsx
@@ -45,7 +45,7 @@ export const MRT_RowPinButton = <TData extends Record<string, any>>({
         onMouseEnter={() => setTooltipOpened(true)}
         onMouseLeave={() => setTooltipOpened(false)}
         size="xs"
-        variant="transparent"
+        variant="subtle"
         style={{
           height: '24px',
           width: '24px',

--- a/packages/mantine-react-table/src/head/MRT_TableHeadCellFilterContainer.tsx
+++ b/packages/mantine-react-table/src/head/MRT_TableHeadCellFilterContainer.tsx
@@ -70,7 +70,7 @@ export const MRT_TableHeadCellFilterContainer = <
                 <Menu.Target>
                   <ActionIcon
                     color="gray"
-                    variant="transparent"
+                    variant="subtle"
                     aria-label={localization.changeFilterMode}
                     size="md"
                   >

--- a/packages/mantine-react-table/src/inputs/MRT_FilterTextInput.tsx
+++ b/packages/mantine-react-table/src/inputs/MRT_FilterTextInput.tsx
@@ -241,7 +241,7 @@ export const MRT_FilterTextInput = <TData extends Record<string, any> = {}>({
   const ClearButton = filterValue ? (
     <ActionIcon
       aria-label={localization.clearFilter}
-      color="gray"
+      color="var(--mantine-color-gray-7)"
       onClick={handleClear}
       size="sm"
       title={localization.clearFilter ?? ''}
@@ -299,6 +299,9 @@ export const MRT_FilterTextInput = <TData extends Record<string, any> = {}>({
             selectProps.ref.current = node;
           }
         }
+      }}
+      clearButtonProps={{
+        size: 'md',
       }}
     />
   ) : isDateFilter ? (

--- a/packages/mantine-react-table/src/menus/MRT_ColumnActionMenu.tsx
+++ b/packages/mantine-react-table/src/menus/MRT_ColumnActionMenu.tsx
@@ -257,7 +257,7 @@ export const MRT_ColumnActionMenu = <TData extends Record<string, any> = {}>({
             {...actionIconProps}
             size="sm"
             color="gray"
-            variant="transparent"
+            variant="subtle"
           >
             <IconDotsVertical />
           </ActionIcon>

--- a/packages/mantine-react-table/src/menus/MRT_RowActionMenu.tsx
+++ b/packages/mantine-react-table/src/menus/MRT_RowActionMenu.tsx
@@ -43,7 +43,7 @@ export const MRT_RowActionMenu = <TData extends Record<string, any> = {}>({
             color="gray"
             onClick={(event) => event.stopPropagation()}
             size="sm"
-            variant="transparent"
+            variant="subtle"
           >
             <IconDots />
           </ActionIcon>


### PR DESCRIPTION
Making the filter input clear buttons consistent in size and colour with the default Select clear button.
Fixes #203.

![image](https://github.com/KevinVandy/mantine-react-table/assets/84348947/ddb4152b-f07c-4896-9bdc-0b5f087ebf25)

Additionally modifying column and row buttons to be of variant `subtle` to display the hover effect and have them be consistent with v1.

![image](https://github.com/KevinVandy/mantine-react-table/assets/84348947/2cd6403c-c5ab-464e-93df-3e24e4a9e3eb)
![image](https://github.com/KevinVandy/mantine-react-table/assets/84348947/d43b9b15-701f-4ee3-8384-ea9ef16ba919)


