### PR TITLE
Prevent Rows per page deselection

### DIFF
--- a/packages/mantine-react-table/src/toolbar/MRT_TablePagination.tsx
+++ b/packages/mantine-react-table/src/toolbar/MRT_TablePagination.tsx
@@ -87,6 +87,7 @@ export const MRT_TablePagination = <TData extends Record<string, any> = {}>({
             data={paginationProps?.rowsPerPageOptions ?? defaultRowsPerPage}
             onChange={(value: string | null) => setPageSize(+(value as string))}
             value={pageSize.toString()}
+            allowDeselect={false}
           />
         </Group>
       )}


### PR DESCRIPTION
The `Rows per page` Select component was able to be deselected which would default to displaying one row per page. Setting `allowDeseect` on the Select component fixes this issue.
Fixes #211.

**Before**

https://github.com/KevinVandy/mantine-react-table/assets/84348947/dcefb384-4cd7-4d1d-8f11-74d386f2876b

**After**

https://github.com/KevinVandy/mantine-react-table/assets/84348947/894dbfaa-3de0-4d26-9ef2-e00f48754837

