### PR TITLE
Fix alert banner overlapping with first row

### DIFF
--- a/packages/mantine-react-table/src/toolbar/MRT_ToolbarAlertBanner.tsx
+++ b/packages/mantine-react-table/src/toolbar/MRT_ToolbarAlertBanner.tsx
@@ -98,7 +98,7 @@ export const MRT_ToolbarAlertBanner = <TData extends Record<string, any> = {}>({
             !positionToolbarAlertBanner &&
             classes['alert-stacked'],
           !stackAlertBanner &&
-            positionToolbarAlertBanner &&
+            positionToolbarAlertBanner ==='bottom' &&
             classes['alert-bottom'],
           alertProps?.className,
         )}


### PR DESCRIPTION
The ToolbarAlertBanner would overlap with the first row of the table when positioned at the top. This was caused by adding the `alert-bottom` class to the Banner regardless of where the banner was positioned. The `alert-bottom` class adds `-16px` to the bottom margin which is only necessary when the banner is at the bottom.

Fixes #209.

**Before**

![image](https://github.com/KevinVandy/mantine-react-table/assets/84348947/d61ef224-f768-4040-90ba-a0f49810f3aa)

**After**
![image](https://github.com/KevinVandy/mantine-react-table/assets/84348947/f5e0550e-ca08-402a-acd3-b4a043bd782f)

The bottom banner is still positioned correctly
![image](https://github.com/KevinVandy/mantine-react-table/assets/84348947/891085d7-9d35-454e-ac04-91bf135d37a0)
