### PR TITLE
Fix detail panel styling

### DIFF
--- a/packages/mantine-react-table/src/body/MRT_TableDetailPanel.module.css
+++ b/packages/mantine-react-table/src/body/MRT_TableDetailPanel.module.css
@@ -18,9 +18,6 @@
   display: table-cell;
   transition: all 100ms ease-in-out;
   width: var(--mrt-inner-width);
-  padding-top: 0 !important;
-  padding-bottom: 0 !important;
-  border-bottom: none;
 }
 
 .inner-grid {
@@ -28,9 +25,12 @@
 }
 
 .inner-expanded {
-  padding-top: 16px !important;
-  padding-bottom: 16px !important;
-  border-bottom: unset;
+  padding: 16px !important;
+  border-bottom: rem(1px) solid var(--_table-border-color) !important;
+}
+
+.inner-collapsed {
+  padding: 0 !important;
 }
 
 .inner-virtual {

--- a/packages/mantine-react-table/src/body/MRT_TableDetailPanel.module.css
+++ b/packages/mantine-react-table/src/body/MRT_TableDetailPanel.module.css
@@ -25,12 +25,7 @@
 }
 
 .inner-expanded {
-  padding: 16px !important;
-  border-bottom: rem(1px) solid var(--_table-border-color) !important;
-}
-
-.inner-collapsed {
-  padding: 0 !important;
+  border-bottom: rem(1px) solid var(--_table-border-color);
 }
 
 .inner-virtual {

--- a/packages/mantine-react-table/src/body/MRT_TableDetailPanel.tsx
+++ b/packages/mantine-react-table/src/body/MRT_TableDetailPanel.tsx
@@ -83,7 +83,7 @@ export const MRT_TableDetailPanel = <TData extends Record<string, any> = {}>({
           'mantine-Table-td-detail-panel',
           classes.inner,
           layoutMode?.startsWith('grid') && classes['inner-grid'],
-          row.getIsExpanded() && classes['inner-expanded'],
+          row.getIsExpanded() ? classes['inner-expanded'] : classes['inner-collapsed'],
           virtualRow && classes['inner-virtual'],
         )}
       >

--- a/packages/mantine-react-table/src/body/MRT_TableDetailPanel.tsx
+++ b/packages/mantine-react-table/src/body/MRT_TableDetailPanel.tsx
@@ -83,9 +83,10 @@ export const MRT_TableDetailPanel = <TData extends Record<string, any> = {}>({
           'mantine-Table-td-detail-panel',
           classes.inner,
           layoutMode?.startsWith('grid') && classes['inner-grid'],
-          row.getIsExpanded() ? classes['inner-expanded'] : classes['inner-collapsed'],
+          row.getIsExpanded() && classes['inner-expanded'],
           virtualRow && classes['inner-virtual'],
         )}
+        p={row.getIsExpanded() ? "md" : 0}
       >
         {renderDetailPanel && (
           <Collapse in={row.getIsExpanded()}>


### PR DESCRIPTION
When detail panel is expanded:
- Adds top and bottom padding
- Adds bottom border

Fixes #208 

**Collapsed**
![image](https://github.com/KevinVandy/mantine-react-table/assets/84348947/c031ff7b-e579-4bf3-b81f-dce834031288)

**Expanded**
![image](https://github.com/KevinVandy/mantine-react-table/assets/84348947/e66b375b-8972-488a-83ba-28ac376ad464)
