### PR TITLE
Fix loading overlay

### DIFF
--- a/packages/mantine-react-table/src/table/MRT_TableContainer.tsx
+++ b/packages/mantine-react-table/src/table/MRT_TableContainer.tsx
@@ -90,6 +90,7 @@ export const MRT_TableContainer = <TData extends Record<string, any> = {}>({
     >
       <LoadingOverlay
         visible={isLoading || showLoadingOverlay}
+        zIndex={1}
         {...loadingOverlayProps}
       />
       <MRT_Table table={table} />

--- a/packages/mantine-react-table/src/table/MRT_TableContainer.tsx
+++ b/packages/mantine-react-table/src/table/MRT_TableContainer.tsx
@@ -90,7 +90,7 @@ export const MRT_TableContainer = <TData extends Record<string, any> = {}>({
     >
       <LoadingOverlay
         visible={isLoading || showLoadingOverlay}
-        zIndex={1}
+        zIndex={2}
         {...loadingOverlayProps}
       />
       <MRT_Table table={table} />


### PR DESCRIPTION
Fix LoadingOverlay by setting its z-index to `1`.

Fixes #207.

![image](https://github.com/KevinVandy/mantine-react-table/assets/84348947/682a6e8e-cf1c-48d0-bcbf-22b5af1d0755)
