### PR TITLE
French locale : fix words order in Hide column translation

### DIFF
--- a/packages/mantine-react-table/src/locales/fr.ts
+++ b/packages/mantine-react-table/src/locales/fr.ts
@@ -51,7 +51,7 @@ export const MRT_Localization_FR: MRT_Localization = {
   groupByColumn: 'Grouper par {column}',
   groupedBy: 'Groupé par ',
   hideAll: 'Cacher tout',
-  hideColumn: 'Cacher {column} colonne',
+  hideColumn: 'Cacher colonne {column}',
   max: 'Max',
   min: 'Min',
   move: 'Déplacer',


### PR DESCRIPTION
Fix incorrect order of words : change wrong "Cacher XXX colonne" to "Cacher colonne XXX"