### PR TITLE
Remove extra padding on virtualization pinned columns

### DIFF
--- a/packages/mantine-react-table/src/table/MRT_Table.tsx
+++ b/packages/mantine-react-table/src/table/MRT_Table.tsx
@@ -88,7 +88,8 @@ export const MRT_Table = <TData extends MRT_RowData>({
               .map(
                 (c) =>
                   table.getVisibleLeafColumns().length - c.getPinnedIndex() - 1,
-              ),
+              )
+              .sort((a, b) => a - b),
           ]
         : [[], []],
     [columnPinning, enableColumnVirtualization, enableColumnPinning],
@@ -129,11 +130,18 @@ export const MRT_Table = <TData extends MRT_RowData>({
   let virtualPaddingRight: number | undefined;
 
   if (columnVirtualizer && virtualColumns?.length) {
-    virtualPaddingLeft = virtualColumns[leftPinnedIndexes.length]?.start ?? 0;
+    virtualPaddingLeft =
+      (virtualColumns[leftPinnedIndexes.length]?.start ?? 0) -
+      (virtualColumns[leftPinnedIndexes.length - 1]?.end ?? 0);
     virtualPaddingRight =
       columnVirtualizer.getTotalSize() -
-      (virtualColumns[virtualColumns.length - 1 - rightPinnedIndexes.length]
-        ?.end ?? 0);
+      (virtualColumns[virtualColumns.length - rightPinnedIndexes.length - 1]
+        ?.end ?? 0) -
+      (rightPinnedIndexes.length
+        ? columnVirtualizer.getTotalSize() -
+          (virtualColumns[virtualColumns.length - rightPinnedIndexes.length]
+            ?.start ?? 0)
+        : 0);
   }
 
   const props = {


### PR DESCRIPTION
https://www.mantine-react-table.dev/?path=/story/features-virtualization--enable-column-virtualization-with-pinning

Extra padding is added when pinning on virtualization columns.
Fix the padding by subtracting the size of the pinned column.

Before
<img width="617" alt="スクリーンショット 2023-12-28 0 56 07" src="https://github.com/KevinVandy/mantine-react-table/assets/153734687/997a4b2e-516b-4f81-ad17-a27b31236db6">

After
<img width="408" alt="スクリーンショット 2023-12-28 1 02 17" src="https://github.com/KevinVandy/mantine-react-table/assets/153734687/72a6391f-26ee-4d44-838a-ad92218992f5">
