### PR TITLE
Fix bug when empty data in enableColumnVirtualization

### DIFF
--- a/packages/mantine-react-table/src/hooks/useMRT_ColumnVirtualizer.ts
+++ b/packages/mantine-react-table/src/hooks/useMRT_ColumnVirtualizer.ts
@@ -27,7 +27,7 @@ export const useMRT_ColumnVirtualizer = <
     },
     refs: { tableContainerRef },
   } = table;
-  const { columnPinning, columnVisibility, draggingColumn } = getState();
+  const { columnPinning, draggingColumn } = getState();
 
   const columnVirtualizerProps = parseFromValuesOrFunc(
     columnVirtualizerOptions,
@@ -53,19 +53,7 @@ export const useMRT_ColumnVirtualizer = <
     [columnPinning, enableColumnVirtualization, enableColumnPinning],
   );
 
-  //get first 16 column widths and average them if calc is needed
-  const averageColumnWidth = useMemo(() => {
-    if (!enableColumnVirtualization || columnVirtualizerProps?.estimateSize) {
-      return 0;
-    }
-    const columnsWidths =
-      table
-        .getRowModel()
-        .rows[0]?.getCenterVisibleCells()
-        ?.slice(0, 16)
-        ?.map((cell) => cell.column.getSize() * 1.2) ?? [];
-    return columnsWidths.reduce((a, b) => a + b, 0) / columnsWidths.length;
-  }, [table.getRowModel().rows, columnPinning, columnVisibility]);
+  const columns = table.getAllColumns();
 
   const draggingColumnIndex = draggingColumn?.id
     ? table
@@ -76,7 +64,7 @@ export const useMRT_ColumnVirtualizer = <
   const columnVirtualizer = enableColumnVirtualization
     ? (useVirtualizer({
         count: table.getVisibleLeafColumns().length,
-        estimateSize: () => averageColumnWidth,
+        estimateSize: (index) => columns[index].getSize(),
         getScrollElement: () => tableContainerRef.current,
         horizontal: true,
         overscan: 3,

--- a/packages/mantine-react-table/stories/features/RowOrdering.stories.tsx
+++ b/packages/mantine-react-table/stories/features/RowOrdering.stories.tsx
@@ -1,9 +1,5 @@
 import { useState } from 'react';
-import {
-  type MRT_ColumnDef,
-  type MRT_Row,
-  MantineReactTable,
-} from '../../src';
+import { type MRT_ColumnDef, type MRT_Row, MantineReactTable } from '../../src';
 import { faker } from '@faker-js/faker';
 import { type Meta } from '@storybook/react';
 

--- a/packages/mantine-react-table/stories/features/Virtualization.stories.tsx
+++ b/packages/mantine-react-table/stories/features/Virtualization.stories.tsx
@@ -354,3 +354,19 @@ export const MaxVirtualization = () => (
     mantineTableContainerProps={{ style: { maxHeight: 500 } }}
   />
 );
+
+export const EmptyDataVirtualization = () => (
+  <MantineReactTable
+    columns={fakeColumns}
+    data={[]}
+    enableBottomToolbar={false}
+    enableColumnPinning
+    enableColumnResizing
+    enableColumnVirtualization
+    enablePagination={false}
+    enableRowNumbers
+    enableRowVirtualization
+    mantinePaperProps={{ style: { margin: 'auto', maxWidth: 1000 } }}
+    mantineTableContainerProps={{ style: { maxHeight: 500 } }}
+  />
+);


### PR DESCRIPTION
If you load empty data with enableColumnVirtualization, it will be displayed from the middle as shown in the screenshot.

<img width="1011" alt="スクリーンショット 2024-01-21 7 44 51" src="https://github.com/KevinVandy/mantine-react-table/assets/153734687/c2aa8ad2-2c84-43f4-85ff-8aa5a82a3887">


The tanstack table example does not seem to support empty data or variable column sizes.
[React Example: Virtualized Columns](https://github.com/TanStack/table/blob/764d5db0a644880576f8bc23db298849fcb3c324/examples/react/virtualized-columns/src/main.tsx#L42)