### PR TITLE
Add a table option for IME input

### DIFF
--- a/packages/mantine-react-table/src/components/inputs/MRT_EditCellTextInput.tsx
+++ b/packages/mantine-react-table/src/components/inputs/MRT_EditCellTextInput.tsx
@@ -69,7 +69,7 @@ export const MRT_EditCellTextInput = <TData extends MRT_RowData>({
 
   const handleEnterKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
     textInputProps.onKeyDown?.(event);
-    if (event.key === 'Enter') {
+    if (event.key === 'Enter' && table.options.enableIMEMode !== true) {
       editInputRefs.current[cell.id]?.blur();
     }
   };

--- a/packages/mantine-react-table/src/types.ts
+++ b/packages/mantine-react-table/src/types.ts
@@ -829,6 +829,7 @@ export type MRT_TableOptions<TData extends MRT_RowData> = Omit<
   enableFullScreenToggle?: boolean;
   enableGlobalFilterModes?: boolean;
   enableGlobalFilterRankedResults?: boolean;
+  enableIMEMode?: boolean;
   enablePagination?: boolean;
   enableRowActions?: boolean;
   enableRowDragging?: boolean;

--- a/packages/mantine-react-table/stories/features/Editing.stories.tsx
+++ b/packages/mantine-react-table/stories/features/Editing.stories.tsx
@@ -308,6 +308,54 @@ export const EditingEnabledEditModeCustom = () => {
   );
 };
 
+export const EditingEnabledEditModeWithIMEInput = () => {
+  const [tableData, setTableData] = useState(data);
+  const handleSaveRow: MRT_TableOptions<Person>['onEditingRowSave'] = ({
+    exitEditingMode,
+    row,
+    values,
+  }) => {
+    tableData[row.index] = values;
+    setTableData([...tableData]);
+    exitEditingMode();
+  };
+
+  const columns = [
+    {
+      accessorKey: 'firstName',
+      header: 'First Name',
+    },
+    {
+      accessorKey: 'lastName',
+      header: 'Last Name',
+    },
+    {
+      accessorKey: 'address',
+      header: 'Address',
+    },
+    {
+      accessorKey: 'state',
+      header: 'State',
+    },
+    {
+      accessorKey: 'phoneNumber',
+      enableEditing: false,
+      header: 'Phone Number',
+    },
+  ];
+
+  return (
+    <MantineReactTable
+      columns={columns}
+      data={tableData}
+      enableEditing
+      enableIMEMode
+      enableRowNumbers
+      onEditingRowSave={handleSaveRow}
+    />
+  );
+};
+
 export const CustomEditModal = () => {
   const [tableData, setTableData] = useState(data);
 


### PR DESCRIPTION
Thank you for creating a great library.
I added enableIMEMode to table option.
IME is an operating system program that enables users to generate characters not natively available on their input devices by using sequences of characters that are available to them.
IME use Enter key as submit so the entered characters may be repeated twice in MRT.

https://github.com/KevinVandy/mantine-react-table/assets/91565962/99f868f1-9598-41ca-af73-cc8771a5fed9

