### PR TITLE
Fixed CSS property typo of z-index as zindex

### DIFF
--- a/packages/mantine-react-table/src/components/body/MRT_TableBodyCell.module.css
+++ b/packages/mantine-react-table/src/components/body/MRT_TableBodyCell.module.css
@@ -72,7 +72,7 @@
     width: 100%;
     height: 100%;
     background-color: transparent;
-    zindex: -1;
+    z-index: -1;
   }
 }
 


### PR DESCRIPTION
Corrected the mistyped 'zindex' CSS property to the correct 'z-index' in a table body cell style.