### PR TITLE
fix some console warnings in various places

### DIFF
--- a/packages/mantine-react-table/src/components/buttons/MRT_CopyButton.tsx
+++ b/packages/mantine-react-table/src/components/buttons/MRT_CopyButton.tsx
@@ -19,12 +19,16 @@ interface Props<TData extends MRT_RowData, TValue = MRT_CellValue>
   extends UnstyledButtonProps {
   cell: MRT_Cell<TData, TValue>;
   children: ReactNode;
+  renderedColumnIndex?: number;
+  renderedRowIndex?: number;
   table: MRT_TableInstance<TData>;
 }
 
 export const MRT_CopyButton = <TData extends MRT_RowData>({
   cell,
   children,
+  renderedColumnIndex,
+  renderedRowIndex,
   table,
   ...rest
 }: Props<TData>) => {

--- a/packages/mantine-react-table/src/components/table/MRT_Table.tsx
+++ b/packages/mantine-react-table/src/components/table/MRT_Table.tsx
@@ -63,7 +63,7 @@ export const MRT_Table = <TData extends MRT_RowData>({
         'mrt-table',
         classes.root,
         layoutMode?.startsWith('grid') && classes['root-grid'],
-        tableProps?.className,
+        tableProps.className,
       )}
       highlightOnHover
       horizontalSpacing={density}
@@ -71,7 +71,7 @@ export const MRT_Table = <TData extends MRT_RowData>({
       {...tableProps}
       __vars={{
         ...columnSizeVars,
-        ...tableProps?.__vars,
+        ...tableProps.__vars,
       }}
     >
       {enableTableHead && <MRT_TableHead {...commonTableGroupProps} />}
@@ -80,7 +80,7 @@ export const MRT_Table = <TData extends MRT_RowData>({
       ) : (
         <MRT_TableBody
           {...commonTableGroupProps}
-          enableHover={tableProps?.highlightOnHover}
+          enableHover={tableProps.highlightOnHover}
           isStriped={tableProps.striped}
         />
       )}

--- a/packages/mantine-react-table/stories/features/Virtualization.stories.tsx
+++ b/packages/mantine-react-table/stories/features/Virtualization.stories.tsx
@@ -124,13 +124,7 @@ export const EnableRowVirtualizationSpacious = () => (
 
 export const EnableRowVirtualizationTallContent = () => (
   <MantineReactTable
-    columns={[
-      ...longColumns,
-      {
-        accessorKey: 'favoriteQuote',
-        header: 'Favorite Quote',
-      },
-    ]}
+    columns={longColumns}
     data={longData}
     enableBottomToolbar={false}
     enablePagination={false}

--- a/packages/mantine-react-table/stories/styling/CustomTableBody.stories.tsx
+++ b/packages/mantine-react-table/stories/styling/CustomTableBody.stories.tsx
@@ -50,7 +50,7 @@ export const CustomTableBody = () => (
     columns={columns}
     data={data}
     mantineTableBodyProps={{
-      children: 'Custom Table Body',
+      children: <div>Custom Table Body</div>,
     }}
   />
 );

--- a/packages/mantine-react-table/stories/styling/Theming.stories.tsx
+++ b/packages/mantine-react-table/stories/styling/Theming.stories.tsx
@@ -40,40 +40,54 @@ export const DefaultTheme = () => (
 );
 
 export const CustomLightTheme = () => {
-  // const theme = createTheme({
-  //   palette: {
-  //     primary: {
-  //       main: '#ff9800',
-  //     },
-  //     background: {
-  //       default: '#ffffef',
-  //     },
-  //     secondary: {
-  //       main: '#00bcd4',
-  //     },
-  //   },
-  // });
   return (
-    <MantineProvider theme={{ primaryColor: '#ff9800' }}>
+    <MantineProvider
+      theme={{
+        colors: {
+          'bright-pink': [
+            '#F0BBDD',
+            '#ED9BCF',
+            '#EC7CC3',
+            '#ED5DB8',
+            '#F13EAF',
+            '#F71FA7',
+            '#FF00A1',
+            '#E00890',
+            '#C50E82',
+            '#AD1374',
+          ],
+        },
+        primaryColor: 'bright-pink',
+        primaryShade: { dark: 7, light: 6 },
+      }}
+    >
       <MantineReactTable columns={columns} data={data} enableRowSelection />
     </MantineProvider>
   );
 };
 
 export const CustomDarkTheme = () => {
-  // const theme = createTheme({
-  //   palette: {
-  //     mode: 'dark',
-  //     primary: {
-  //       main: '#81980f',
-  //     },
-  //     secondary: {
-  //       main: '#00bcd4',
-  //     },
-  //   },
-  // });
   return (
-    <MantineProvider theme={{ colorScheme: 'dark', primaryColor: '#81980f' }}>
+    <MantineProvider
+      theme={{
+        colors: {
+          'bright-pink': [
+            '#F0BBDD',
+            '#ED9BCF',
+            '#EC7CC3',
+            '#ED5DB8',
+            '#F13EAF',
+            '#F71FA7',
+            '#FF00A1',
+            '#E00890',
+            '#C50E82',
+            '#AD1374',
+          ],
+        },
+        primaryColor: 'bright-pink',
+        primaryShade: { dark: 7, light: 6 },
+      }}
+    >
       <MantineReactTable columns={columns} data={data} enableRowSelection />
     </MantineProvider>
   );


### PR DESCRIPTION
renderedColumnIndex and renderedRowIndex were being spread into the MRT_CopyButton 
tableProps isn't ever null in MRT_Table
quieted down some noise from a few storybooks.