### PR TITLE
Fix css typo in MRT_TableFooterCell.module.css

### DIFF
--- a/packages/mantine-react-table/src/components/footer/MRT_TableFooterCell.module.css
+++ b/packages/mantine-react-table/src/components/footer/MRT_TableFooterCell.module.css
@@ -16,7 +16,7 @@
     justify-content: center;
   }
 
-  background-color: var(----mrt-base-background-color);
+  background-color: var(--mrt-base-background-color);
 
   &[data-column-pinned] {
     position: sticky;


### PR DESCRIPTION
Footer cells currently have no background because of this typo.