### PR TITLE
fix: css target correct global filter element

### DIFF
--- a/packages/mantine-react-table/src/components/inputs/MRT_GlobalFilterTextInput.module.css
+++ b/packages/mantine-react-table/src/components/inputs/MRT_GlobalFilterTextInput.module.css
@@ -4,10 +4,8 @@
 }
 
 .collapse {
-  & > div {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    flex-wrap: nowrap;
-  }
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-wrap: nowrap;
 }


### PR DESCRIPTION
Fixing the `MRT_GlobalFilterTextInput` to align the search icon button and the input field.

From: 
![image](https://github.com/KevinVandy/mantine-react-table/assets/6643053/2ab7f51a-6358-4e71-a9a9-7651af018b18)

To: 
![image](https://github.com/KevinVandy/mantine-react-table/assets/6643053/53c384e5-5df8-44cd-af06-e9d9fcafb241)
