### PR TITLE
style: assign detail panel background color when virtualisation is true

### DIFF
--- a/packages/mantine-react-table/src/components/body/MRT_TableDetailPanel.module.css
+++ b/packages/mantine-react-table/src/components/body/MRT_TableDetailPanel.module.css
@@ -1,6 +1,7 @@
 .root {
   display: table-row;
   width: 100%;
+  background-color: var(--mrt-base-background-color);
 }
 
 .root-grid {
@@ -30,6 +31,5 @@
 }
 
 .inner-virtual {
-  background-color: var(--mrt-base-background-color);
   transition: none;
 }


### PR DESCRIPTION
Related to [this issue](https://github.com/KevinVandy/mantine-react-table/issues/285)

**Issue**
When using `renderDetailPanel` prop in combination with `enableRowVirtualization` set to true, there's a limitation where consumers cannot override the background color using the `mantineTableBodyRowProps`. 

**Suggestion**
Since the detailed panel spans the entire row element, the `background-color` attribute can be applied to the `<tr />` element instead of individual `<td />` elements.

**Usage example**
```typescript
import classes from './DetailedPanel.module.css';
...

 <MantineReactTable
    columns={...}
    data={...}
    enableRowVirtualization={true}
    mantineTableBodyRowProps={({ isDetailPanel }) => {
      return isDetailPanel
        ? {
            className: classes.detailPanel,
          }
        : {};
    }}
    renderDetailPanel={({ row }) => (...)}
  />
```

**note**
Please feel free to let me know if there is a simpler way to apply background color instead of this change 🍭