### PR TITLE
Added arrIncludes and arrIncludesAll to multi-select filters

### DIFF
--- a/packages/mantine-react-table/src/components/inputs/MRT_FilterTextInput.tsx
+++ b/packages/mantine-react-table/src/components/inputs/MRT_FilterTextInput.tsx
@@ -262,7 +262,6 @@ export const MRT_FilterTextInput = <TData extends MRT_RowData>({
       <Badge
         className={classes['filter-chip-badge']}
         onClick={handleClearEmptyFilterChip}
-        rightSection={ClearButton}
         size="lg"
       >
         {filterChipLabel}
@@ -271,6 +270,7 @@ export const MRT_FilterTextInput = <TData extends MRT_RowData>({
   ) : isMultiSelectFilter ? (
     <MultiSelect
       {...commonProps}
+      clearable
       searchable
       {...multiSelectProps}
       className={clsx(className, multiSelectProps.className)}
@@ -287,6 +287,7 @@ export const MRT_FilterTextInput = <TData extends MRT_RowData>({
       }}
       rightSection={filterValue?.toString()?.length ? ClearButton : undefined}
       style={commonProps.style}
+      value={Array.isArray(commonProps?.value) ? commonProps.value : []}
     />
   ) : isSelectFilter ? (
     <Select

--- a/packages/mantine-react-table/src/components/menus/MRT_FilterOptionMenu.tsx
+++ b/packages/mantine-react-table/src/components/menus/MRT_FilterOptionMenu.tsx
@@ -97,6 +97,18 @@ export const mrtFilterOptions = (
     option: 'notEmpty',
     symbol: '!∅',
   },
+  {
+    divider: false,
+    label: localization.filterArrIncludes,
+    option: 'arrIncludes',
+    symbol: '∈',
+  },
+  {
+    divider: false,
+    label: localization.filterArrIncludesAll,
+    option: 'arrIncludesAll',
+    symbol: '=',
+  },
 ];
 
 const rangeModes = ['between', 'betweenInclusive', 'inNumberRange'];

--- a/packages/mantine-react-table/stories/features/Filtering.stories.tsx
+++ b/packages/mantine-react-table/stories/features/Filtering.stories.tsx
@@ -385,7 +385,18 @@ export const EnableFilterModes = () => (
       },
       {
         accessorKey: 'state',
+        columnFilterModeOptions: [
+          'empty',
+          'notEmpty',
+          'arrIncludes',
+          'arrIncludesAll',
+          'arrIncludesSome',
+        ],
+        filterVariant: 'multi-select',
         header: 'State',
+        mantineFilterMultiSelectProps: {
+          data: Array.from(new Set(data.map((d) => d.state))),
+        },
       },
     ]}
     data={data}


### PR DESCRIPTION
* Added `arrIncludesAll` and `arrIncludesSome` for `multi-select` filter
* Fixed a bug that caused the table to crash when switching from empty/non-empty filters to arr* filters
* Added clearable option to multi-select
* Removed clear button from the empty/non-empty pill as it was not working and the filtering can be removed by just using the option menu

Closes #296 