### PR TITLE
fix: do not call accessorFn if table is loading

### DIFF
--- a/packages/mantine-react-table/src/utils/column.utils.ts
+++ b/packages/mantine-react-table/src/utils/column.utils.ts
@@ -90,6 +90,13 @@ export const prepareColumns = <TData extends MRT_RowData>({
         ...columnDef,
       };
     }
+    if (columnDef?.accessorFn !== undefined) {
+      // If there is an accessorFn defined, make sure not to call it if the table is loading
+      columnDef.accessorFn = (...args) =>
+        !tableOptions?.state?.isLoading &&
+        !tableOptions?.state?.showSkeletons &&
+        columnDef.accessorFn!(...args);
+    }
     return columnDef;
   }) as MRT_DefinedColumnDef<TData>[];
 };

--- a/packages/mantine-react-table/stories/fixed-bugs/loading.stories.tsx
+++ b/packages/mantine-react-table/stories/fixed-bugs/loading.stories.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { Menu } from '@mantine/core';
 import { type MRT_ColumnDef, MantineReactTable } from '../../src';
 import { type Meta } from '@storybook/react';
 
@@ -209,6 +210,50 @@ export const NestedLoadingDataWithInitialSort = () => {
         isLoading: true,
         sorting: [{ desc: false, id: 'name.lastName' }],
       }}
+    />
+  );
+};
+
+export const EmptyDatasetWithLoadingState = () => {
+  const columns = useMemo<MRT_ColumnDef<Person>[]>(
+    () => [
+      {
+        accessorFn: (row) => row.name.firstName,
+        header: 'First Name',
+      },
+      {
+        accessorKey: 'name.lastName',
+        header: 'Last Name',
+      },
+      {
+        accessorKey: 'address',
+        header: 'Address',
+      },
+      {
+        accessorKey: 'city',
+        header: 'City',
+      },
+      {
+        accessorKey: 'state',
+        header: 'State',
+      },
+    ],
+    [],
+  );
+
+  return (
+    <MantineReactTable
+      columns={columns}
+      data={[]}
+      editDisplayMode="table"
+      enableEditing
+      enableRowActions
+      renderRowActionMenuItems={() => (
+        <>
+          <Menu.Item onClick={() => console.info('Delete')}>Delete</Menu.Item>
+        </>
+      )}
+      state={{ isLoading: true }}
     />
   );
 };


### PR DESCRIPTION
If `accessorFn` is defined, make sure not to call it if the table is loading.

Closes #304 