### PR TITLE
Popover Filter Label not shown and Fix for RangeError Maximum call stack size exceeded

### DIFF
--- a/packages/mantine-react-table/src/components/head/MRT_TableHeadCellFilterLabel.module.css
+++ b/packages/mantine-react-table/src/components/head/MRT_TableHeadCellFilterLabel.module.css
@@ -6,10 +6,7 @@
     var(--mantine-color-gray-1),
     var(--mantine-color-dark-6)
   );
-  --ai-color: light-dark(
-    var(--mantine-color-gray-5),
-    var(--mantine-color-dark-3)
-  );
+  color: var(--mantine-color-bright);
   &[data-active] {
     color: var(--mantine-primary-color-filled);
   }

--- a/packages/mantine-react-table/src/utils/column.utils.ts
+++ b/packages/mantine-react-table/src/utils/column.utils.ts
@@ -92,10 +92,12 @@ export const prepareColumns = <TData extends MRT_RowData>({
     }
     if (columnDef?.accessorFn !== undefined) {
       // If there is an accessorFn defined, make sure not to call it if the table is loading
+      const originalAccessorFn = columnDef.accessorFn;
       columnDef.accessorFn = (...args) =>
         !tableOptions?.state?.isLoading &&
-        !tableOptions?.state?.showSkeletons &&
-        columnDef.accessorFn!(...args);
+        !tableOptions?.state?.showSkeletons
+          ? originalAccessorFn(...args)
+          : undefined;
     }
     return columnDef;
   }) as MRT_DefinedColumnDef<TData>[];


### PR DESCRIPTION
- Includes fix where Popover Filter Label was not being shown (CSS copied from SortIcon) (Can be seen in Popover Display Mode story under Filtering Examples)
- Includes fix for storybook getting (RangeError: Maximum call stack size exceeded)