### PR TITLE
Fixed display when multiple selections are selected with pinning on the right

### DIFF
--- a/packages/mantine-react-table/src/components/body/MRT_TableBodyCell.tsx
+++ b/packages/mantine-react-table/src/components/body/MRT_TableBodyCell.tsx
@@ -195,7 +195,7 @@ export const MRT_TableBodyCell = <TData extends MRT_RowData>({
       data-dragging-column={isDraggingColumn || undefined}
       data-first-right-pinned={
         (isColumnPinned === 'right' &&
-          column.getIsLastColumn(isColumnPinned)) ||
+          column.getIsFirstColumn(isColumnPinned)) ||
         undefined
       }
       data-hovered-column-target={isHoveredColumn || undefined}

--- a/packages/mantine-react-table/src/components/footer/MRT_TableFooterCell.tsx
+++ b/packages/mantine-react-table/src/components/footer/MRT_TableFooterCell.tsx
@@ -64,7 +64,7 @@ export const MRT_TableFooterCell = <TData extends MRT_RowData>({
       data-column-pinned={isColumnPinned || undefined}
       data-first-right-pinned={
         (isColumnPinned === 'right' &&
-          column.getIsLastColumn(isColumnPinned)) ||
+          column.getIsFirstColumn(isColumnPinned)) ||
         undefined
       }
       data-index={renderedColumnIndex}

--- a/packages/mantine-react-table/src/components/head/MRT_TableHeadCell.tsx
+++ b/packages/mantine-react-table/src/components/head/MRT_TableHeadCell.tsx
@@ -140,7 +140,7 @@ export const MRT_TableHeadCell = <TData extends MRT_RowData>({
       data-dragging-column={isDraggingColumn || undefined}
       data-first-right-pinned={
         (isColumnPinned === 'right' &&
-          column.getIsLastColumn(isColumnPinned)) ||
+          column.getIsFirstColumn(isColumnPinned)) ||
         undefined
       }
       data-hovered-column-target={isHoveredColumn || undefined}


### PR DESCRIPTION
Fix shadows when multiple selections are made as shown in the screenshot.
<img width="451" alt="スクリーンショット 2024-05-31 0 45 24" src="https://github.com/KevinVandy/mantine-react-table/assets/153734687/ceffebb9-f2da-4850-aeac-d75e812f2c30">
