### PR TITLE
fix minor layout

### DIFF
--- a/packages/mantine-react-table/src/components/head/MRT_TableHeadCell.module.css
+++ b/packages/mantine-react-table/src/components/head/MRT_TableHeadCell.module.css
@@ -10,8 +10,6 @@
   background-clip: padding-box;
   font-weight: bold;
   overflow: visible;
-  padding: calc(var(--mrt-table-head-cell-padding) * 1px);
-  padding-bottom: calc(var(--mrt-table-head-cell-padding) * 2 / 3 * 1px);
   position: relative;
   transition: padding 150ms ease-in-out;
   vertical-align: top;

--- a/packages/mantine-react-table/src/components/head/MRT_TableHeadCell.tsx
+++ b/packages/mantine-react-table/src/components/head/MRT_TableHeadCell.tsx
@@ -55,7 +55,7 @@ export const MRT_TableHeadCell = <TData extends MRT_RowData>({
     refs: { tableHeadCellRefs },
     setHoveredColumn,
   } = table;
-  const { columnSizingInfo, density, draggingColumn, grouping, hoveredColumn } =
+  const { columnSizingInfo, draggingColumn, grouping, hoveredColumn } =
     getState();
   const { column } = header;
   const { columnDef } = column;
@@ -165,8 +165,6 @@ export const MRT_TableHeadCell = <TData extends MRT_RowData>({
           isColumnPinned === 'right'
             ? `${column.getAfter(isColumnPinned)}`
             : undefined,
-        '--mrt-table-head-cell-padding':
-          density === 'xl' ? '23' : density === 'md' ? '16' : '10',
       }}
       align={
         columnDefType === 'group'

--- a/packages/mantine-react-table/src/components/head/MRT_TableHeadCellFilterLabel.module.css
+++ b/packages/mantine-react-table/src/components/head/MRT_TableHeadCellFilterLabel.module.css
@@ -6,6 +6,7 @@
     var(--mantine-color-gray-1),
     var(--mantine-color-dark-6)
   );
+  --ai-hover-color: var(--mantine-color-bright);
   color: var(--mantine-color-bright);
   &[data-active] {
     color: var(--mantine-primary-color-filled);

--- a/packages/mantine-react-table/src/components/head/MRT_TableHeadCellSortLabel.module.css
+++ b/packages/mantine-react-table/src/components/head/MRT_TableHeadCellSortLabel.module.css
@@ -6,6 +6,7 @@
     var(--mantine-color-gray-1),
     var(--mantine-color-dark-6)
   );
+  --ai-hover-color: var(--mantine-color-bright);
   color: var(--mantine-color-bright);
   &[data-sorted] {
     color: var(--mantine-primary-color-filled);

--- a/packages/mantine-react-table/src/components/menus/MRT_ShowHideColumnsMenu.module.css
+++ b/packages/mantine-react-table/src/components/menus/MRT_ShowHideColumnsMenu.module.css
@@ -2,8 +2,9 @@
   max-height: calc(80vh - 100px);
   overflow-y: auto;
   .content {
-    padding: 8px;
-    gap: 8px;
+    padding-top: rem(4px);
+    padding-bottom: rem(4px);
+    gap: rem(8px);
     justify-content: space-between;
   }
 }

--- a/packages/mantine-react-table/src/components/menus/MRT_ShowHideColumnsMenu.tsx
+++ b/packages/mantine-react-table/src/components/menus/MRT_ShowHideColumnsMenu.tsx
@@ -1,7 +1,7 @@
 import clsx from 'clsx';
 import classes from './MRT_ShowHideColumnsMenu.module.css';
 import { useMemo, useState } from 'react';
-import { Button, Divider, Flex, Menu } from '@mantine/core';
+import { Button, Flex, Menu } from '@mantine/core';
 import { MRT_ShowHideColumnsMenuItems } from './MRT_ShowHideColumnsMenuItems';
 import {
   type MRT_Column,
@@ -113,7 +113,7 @@ export const MRT_ShowHideColumnsMenu = <TData extends MRT_RowData>({
           </Button>
         )}
       </Flex>
-      <Divider />
+      <Menu.Divider />
       {allColumns.map((column, index) => (
         <MRT_ShowHideColumnsMenuItems
           allColumns={allColumns}

--- a/packages/mantine-react-table/src/components/menus/MRT_ShowHideColumnsMenuItems.module.css
+++ b/packages/mantine-react-table/src/components/menus/MRT_ShowHideColumnsMenuItems.module.css
@@ -22,7 +22,7 @@
   gap: rem(8px);
 }
 .grab {
-  width: rem(22px);
+  width: rem(28px);
 }
 .pin {
   width: rem(70px);

--- a/packages/mantine-react-table/src/components/table/MRT_TablePaper.tsx
+++ b/packages/mantine-react-table/src/components/table/MRT_TablePaper.tsx
@@ -56,6 +56,8 @@ export const MRT_TablePaper = <TData extends MRT_RowData>({
         ...parseFromValuesOrFunc(tablePaperProps?.style, theme),
         ...(isFullScreen
           ? {
+              border: 0,
+              borderRadius: 0,
               bottom: 0,
               height: '100vh',
               left: 0,

--- a/packages/mantine-react-table/stories/features/ColumnActions.stories.tsx
+++ b/packages/mantine-react-table/stories/features/ColumnActions.stories.tsx
@@ -1,4 +1,4 @@
-import { Divider, Menu } from '@mantine/core';
+import { Menu } from '@mantine/core';
 import { type MRT_ColumnDef, MantineReactTable } from '../../src';
 import { faker } from '@faker-js/faker';
 import { type Meta } from '@storybook/react';
@@ -166,7 +166,7 @@ export const CustomColumnActionsPerColumn = () => (
         renderColumnActionsMenuItems: ({ internalColumnMenuItems }) => (
           <>
             {internalColumnMenuItems}
-            <Divider />
+            <Menu.Divider />
             <Menu.Item>Item 1</Menu.Item>
             <Menu.Item>Item 2</Menu.Item>
           </>


### PR DESCRIPTION
Display position misalignment
<img width="343" alt="スクリーンショット 2024-05-31 1 02 18" src="https://github.com/KevinVandy/mantine-react-table/assets/153734687/8c90f3c4-47f7-4146-82af-60684f39f63e">

Display misalignment at maximum density
<img width="466" alt="スクリーンショット 2024-05-31 1 21 49" src="https://github.com/KevinVandy/mantine-react-table/assets/153734687/0d1f9093-afa7-4e72-a414-13f3f245bd03">

Fixed sort icon hover color in light mode
<img width="251" alt="スクリーンショット 2024-05-31 1 47 53" src="https://github.com/KevinVandy/mantine-react-table/assets/153734687/0788f79e-7492-4e02-803b-92ba9e67bd7f">

Other
- Remove border when in fullscreen
- Changed Divider in menu to Menu.Divider