### PR TITLE
fix: The path to the types in the package.json for the locale is incorrect.

### DIFF
--- a/packages/mantine-react-table/build-locales.mjs
+++ b/packages/mantine-react-table/build-locales.mjs
@@ -95,11 +95,11 @@ export declare const MRT_Localization_${locale
         exports: {
           '.': {
             import: {
-              types: './index.d.cts',
+              types: './index.esm.d.mts',
               default: './index.esm.mjs',
             },
             require: {
-              types: './index.esm.d.mts',
+              types: './index.d.cts',
               default: './index.cjs',
             },
           },


### PR DESCRIPTION
This might be the reason why a complete import path is required in Remix and similar frameworks.

> Note: In some frameworks like Remix, you may need to use a full import path like
> import { MRT_Localization_ES } from 'mantine-react-table/locales/es/index.js'; or
> import { MRT_Localization_ES } from 'mantine-react-table/locales/es/index.esm.js';
> to properly import the locale.