### PR TITLE
fix: error when hiding columns when pinned to the right with virtualized columns enabled

### DIFF
--- a/packages/mantine-react-table/src/hooks/useMRT_ColumnVirtualizer.ts
+++ b/packages/mantine-react-table/src/hooks/useMRT_ColumnVirtualizer.ts
@@ -53,7 +53,7 @@ export const useMRT_ColumnVirtualizer = <
               .sort((a, b) => a - b),
           ]
         : [[], []],
-    [columnPinning, enableColumnPinning],
+    [visibleColumns.length, columnPinning, enableColumnPinning],
   );
 
   const numPinnedLeft = leftPinnedIndexes.length;


### PR DESCRIPTION
The same issue has been reported with the Material React Table.
https://github.com/KevinVandy/material-react-table/issues/1012

Even though the number of items displayed has changed by hiding the column, the pinned index on the right has not changed, causing an error.
Add the number of items displayed to the dependencies of useMemo and update the pinned index.

https://github.com/KevinVandy/mantine-react-table/assets/153734687/bae0b21d-537d-40a8-b753-de1b5021c845
