### PR TITLE
Allow the multi-select filter to work on a column with null inputs

### DIFF
--- a/packages/mantine-react-table/src/components/inputs/MRT_FilterTextInput.tsx
+++ b/packages/mantine-react-table/src/components/inputs/MRT_FilterTextInput.tsx
@@ -117,9 +117,9 @@ export const MRT_FilterTextInput = <TData extends MRT_RowData>({
         multiSelectProps?.data ??
         ((isAutoCompleteFilter || isSelectFilter || isMultiSelectFilter) &&
         facetedUniqueValues
-          ? Array.from(facetedUniqueValues.keys()).sort((a, b) =>
-              a.localeCompare(b),
-            )
+          ? Array.from(facetedUniqueValues.keys())
+              .filter((key) => key !== null)
+              .sort((a, b) => a.localeCompare(b))
           : [])
       )
         //@ts-ignore


### PR DESCRIPTION
This change, which I want to put up for discussion in #346, stops the multi-select filter from crashing if the column in question contains null values. 

It currently comes with a caveat that the null value cannot be selected as a filter. 