### PR TITLE
fix: scroll bug when resizing columns for row-virtualized table.

### DIFF
--- a/packages/mantine-react-table/src/components/table/MRT_Table.tsx
+++ b/packages/mantine-react-table/src/components/table/MRT_Table.tsx
@@ -91,7 +91,7 @@ export const MRT_Table = <TData extends MRT_RowData>({
       }}
     >
       {enableTableHead && <MRT_TableHead {...commonTableGroupProps} />}
-      {memoMode === 'table-body' || columnSizingInfo.isResizingColumn ? (
+      {memoMode === 'table-body' ? (
         <Memo_MRT_TableBody
           {...commonTableGroupProps}
           tableProps={tableProps}


### PR DESCRIPTION
There's been an issue on mantine-react-table that I only see mention of with regards to material-react-table - when the rows of a table are virtualized, resizing a column auto-scrolls you back to the top of the table.

Example issue: https://github.com/KevinVandy/material-react-table/issues/1103
StackBlitz Demonstrating Issue: https://stackblitz.com/edit/vitejs-vite-7pivh8?file=src%2FApp.tsx

After some digging, I discovered it was because the `MRT_TableBody` component is being switched out with the `Memo_MRT_TableBody` component during column resizing via ternary operator. After removing the `columnSizingInfo.isResizingColumn` part of the conditional in `MRT_Table.tsx`, the bug disappears.

This is my first real pull request, so I'm open to criticism & direction. 😊