### PR TITLE
Consider date-range as range filter in filter label

### DIFF
--- a/packages/mantine-react-table/src/head/MRT_TableHeadCellFilterLabel.tsx
+++ b/packages/mantine-react-table/src/head/MRT_TableHeadCellFilterLabel.tsx
@@ -46,6 +46,7 @@ export const MRT_TableHeadCellFilterLabel = <
 
   const isRangeFilter =
     columnDef.filterVariant === 'range' ||
+    columnDef.filterVariant === 'date-range' ||
     ['between', 'betweenInclusive', 'inNumberRange'].includes(
       columnDef._filterFn,
     );


### PR DESCRIPTION
When setting column definition property `filterVariant: "date-range"` in combination with a custom `filterFn`, the filter icon and tooltip are incorrectly shown, even when no filter has been applied.

![image](https://github.com/KevinVandy/mantine-react-table/assets/6730646/8f1f031a-fc11-47a4-93fc-1176e2bf36aa)

The filter label currently only displays properly if the `filterFn` is one of the built in values `['between', 'betweenInclusive', 'inNumberRange']`. This change makes `date-range` always be considered as a range filter, regardless of the filter function.

The bug appears to [exist in v2 also](https://github.com/KevinVandy/mantine-react-table/blob/ff92df3339d58b7cf7301a2ae4b44f02105b056e/packages/mantine-react-table/src/components/head/MRT_TableHeadCellFilterLabel.tsx#L50), I'd be happy to put up another PR if required.