### PR TITLE
fix: multiselect was not saving values when it had no focus

### DIFF
--- a/packages/mantine-react-table/src/components/inputs/MRT_EditCellTextInput.tsx
+++ b/packages/mantine-react-table/src/components/inputs/MRT_EditCellTextInput.tsx
@@ -164,9 +164,12 @@ export const MRT_EditCellTextInput = <TData extends MRT_RowData>({
         value={value}
         {...(selectProps as MRT_MultiSelectProps)}
         onBlur={handleBlur}
-        onChange={(value) => {
+        onChange={(newValue) => {
           (selectProps as MRT_MultiSelectProps).onChange?.(value as any);
-          setValue(value);
+          setValue(newValue);
+          // Save if not in focus, otherwise it will be handled by onBlur
+          if (document.activeElement === editInputRefs.current[cell.id]) return;
+          saveInputValueToRowCache(newValue as any);
         }}
         onClick={(e) => {
           e.stopPropagation();

--- a/packages/mantine-react-table/stories/features/Editing.stories.tsx
+++ b/packages/mantine-react-table/stories/features/Editing.stories.tsx
@@ -421,6 +421,30 @@ export const EditMultiSelectVariant = () => {
   );
 };
 
+export const EditMultiSelectVariantModal = () => {
+  const [tableData, setTableData] = useState(data);
+
+  const handleSaveRow: MRT_TableOptions<Person>['onEditingRowSave'] = ({
+    exitEditingMode,
+    row,
+    values,
+  }) => {
+    tableData[+row.index] = values;
+    setTableData([...tableData]);
+    exitEditingMode();
+  };
+
+  return (
+    <MantineReactTable
+      columns={multiSelectColumns}
+      data={tableData}
+      enableEditing
+      enableRowActions
+      onEditingRowSave={handleSaveRow}
+    />
+  );
+};
+
 export const EditSelectVariant = () => {
   const [tableData, setTableData] = useState(data);
 


### PR DESCRIPTION
When an edit modal had a multiselect input and the pill "X" button was clicked the value was not removed. This is because the `saveInputValueToRowCache` function was only called in the `onBlur` handler. Since the input never gains focus in this case, the handler never gets called and the input's value does not get saved in the row's cache.

This fix calls `saveInputValueToRowCache` inside the `onChange` handler only when the input doesn't have focus.

Closes #381 