### PR TITLE
Fix selected row style

### DIFF
--- a/packages/mantine-react-table/src/components/body/MRT_TableBodyRow.module.css
+++ b/packages/mantine-react-table/src/components/body/MRT_TableBodyRow.module.css
@@ -100,7 +100,7 @@
   /* end column pinning styles */
   /* row pinning styles */
   &[data-row-pinned] {
-    background-color: var(--mantine-color-body);
+    background-color: var(--mrt-pinned-row-background-color, --mantine-color-body);
     bottom: calc(var(--mrt-pinned-row-bottom) * 1px);
     opacity: 0.97;
     top: calc(var(--mrt-pinned-row-top) * 1px);
@@ -141,7 +141,7 @@
 
   /* selection styles */
   &[data-selected] {
-    background-color: var(--mantine-color-body);
+    background-color: var(--mrt-selected-row-background-color, --mantine-color-body);
 
     td {
       &[data-column-pinned] {


### PR DESCRIPTION
Re-apply following colors: 

- `--mrt-selected-row-background-color` for data table row attribute `[data-row-pinned]`
-  `--mrt-pinned-row-background-color` for table row data attribute `[data-selected]`

Introducing fallback color to `--mantine-color-body`