### PR TITLE
fix: add stopPropagation calls to dnd handlers

### DIFF
--- a/packages/mantine-react-table/src/components/body/MRT_TableBodyRowGrabHandle.tsx
+++ b/packages/mantine-react-table/src/components/body/MRT_TableBodyRowGrabHandle.tsx
@@ -33,12 +33,14 @@ export const MRT_TableBodyRowGrabHandle = <TData extends MRT_RowData>({
   };
 
   const handleDragStart = (event: DragEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
     actionIconProps?.onDragStart?.(event);
     event.dataTransfer.setDragImage(rowRef.current as HTMLElement, 0, 0);
     table.setDraggingRow(row as any);
   };
 
   const handleDragEnd = (event: DragEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
     actionIconProps?.onDragEnd?.(event);
     table.setDraggingRow(null);
     table.setHoveredRow(null);

--- a/packages/mantine-react-table/src/components/head/MRT_TableHeadCellGrabHandle.tsx
+++ b/packages/mantine-react-table/src/components/head/MRT_TableHeadCellGrabHandle.tsx
@@ -41,6 +41,7 @@ export const MRT_TableHeadCellGrabHandle = <TData extends MRT_RowData>({
   };
 
   const handleDragStart = (event: DragEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
     actionIconProps?.onDragStart?.(event);
     setDraggingColumn(column);
     event.dataTransfer.setDragImage(
@@ -51,6 +52,7 @@ export const MRT_TableHeadCellGrabHandle = <TData extends MRT_RowData>({
   };
 
   const handleDragEnd = (event: DragEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
     actionIconProps?.onDragEnd?.(event);
     if (hoveredColumn?.id === 'drop-zone') {
       column.toggleGrouping();

--- a/packages/mantine-react-table/src/components/menus/MRT_ShowHideColumnsMenuItems.tsx
+++ b/packages/mantine-react-table/src/components/menus/MRT_ShowHideColumnsMenuItems.tsx
@@ -75,11 +75,13 @@ export const MRT_ShowHideColumnsMenuItems = <TData extends MRT_RowData>({
   const [isDragging, setIsDragging] = useState(false);
 
   const handleDragStart = (e: DragEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
     setIsDragging(true);
     e.dataTransfer.setDragImage(menuItemRef.current as HTMLElement, 0, 0);
   };
 
-  const handleDragEnd = (_e: DragEvent<HTMLButtonElement>) => {
+  const handleDragEnd = (e: DragEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
     setIsDragging(false);
     setHoveredColumn(null);
     if (hoveredColumn) {
@@ -87,7 +89,8 @@ export const MRT_ShowHideColumnsMenuItems = <TData extends MRT_RowData>({
     }
   };
 
-  const handleDragEnter = (_e: DragEvent) => {
+  const handleDragEnter = (e: DragEvent) => {
+    e.stopPropagation();
     if (!isDragging && columnDef.enableColumnOrdering !== false) {
       setHoveredColumn(column);
     }


### PR DESCRIPTION
Fixes https://github.com/KevinVandy/mantine-react-table/issues/383

Without stopping propagation, libraries like react-mosaic may break the dnd features. This solution has been proposed [here](https://github.com/react-dnd/react-dnd/issues/2868#issue-745819161) as well. 