### PR TITLE
Pass ComboboxItem Option to MRT_EditCellTextInput Select onChange handler

### DIFF
--- a/packages/mantine-react-table/src/components/inputs/MRT_EditCellTextInput.tsx
+++ b/packages/mantine-react-table/src/components/inputs/MRT_EditCellTextInput.tsx
@@ -136,8 +136,8 @@ export const MRT_EditCellTextInput = <TData extends MRT_RowData>({
         value={value as any}
         {...(selectProps as MRT_SelectProps)}
         onBlur={handleBlur}
-        onChange={(value) => {
-          (selectProps as MRT_SelectProps).onChange?.(value as any);
+        onChange={(value, option) => {
+          (selectProps as MRT_SelectProps).onChange?.(value as any, option);
           setValue(value);
         }}
         onClick={(e) => {


### PR DESCRIPTION
Currently the option parameter of `<Select />` onChange isn't forwarded to the configurable onChange method. This Pull Request aims to add this functionality, which can be quite useful to have.