### PR TITLE
Fix lexical error for css calculation of pinned rows

### DIFF
--- a/packages/mantine-react-table/src/components/body/MRT_TableBody.module.css
+++ b/packages/mantine-react-table/src/components/body/MRT_TableBody.module.css
@@ -34,8 +34,8 @@
 }
 
 .pinned {
-  bottom: calc(var(--mrt-table-footer-height, unset) * 1px - 1px);
+  bottom: calc(var(--mrt-table-footer-height, 0) * 1px - 1px);
   position: sticky;
-  top: calc(var(--mrt-table-head-height, unset) * 1px - 1px);
+  top: calc(var(--mrt-table-head-height, 0) * 1px - 1px);
   z-index: 1;
 }


### PR DESCRIPTION
Use proper fallback calculation value for pinned top and bottom rows.

This issue solves issue #451 