### PR TITLE
Update tanstack-react-virtual

### DIFF
--- a/packages/mantine-react-table/package.json
+++ b/packages/mantine-react-table/package.json
@@ -135,7 +135,7 @@
   "dependencies": {
     "@tanstack/match-sorter-utils": "8.19.4",
     "@tanstack/react-table": "8.20.5",
-    "@tanstack/react-virtual": "3.10.8"
+    "@tanstack/react-virtual": "3.11.2"
   },
   "peerDependencies": {
     "@mantine/core": "^7.9",


### PR DESCRIPTION
Pins `@tanstack/react-virtual` to v3.11.2 to get rid of the React 19 peer deps warning. No breaking changes since the previous version.