### PR TITLE
fix: unnecessary setPageIndex to the last page when pageIndex is 0

### DIFF
--- a/packages/mantine-react-table/src/hooks/useMRT_Effects.ts
+++ b/packages/mantine-react-table/src/hooks/useMRT_Effects.ts
@@ -71,7 +71,7 @@ export const useMRT_Effects = <TData extends MRT_RowData>(
     if (!enablePagination || isLoading || showSkeletons) return;
     const { pageIndex, pageSize } = pagination;
     const firstVisibleRowIndex = pageIndex * pageSize;
-    if (firstVisibleRowIndex >= totalRowCount) {
+    if (firstVisibleRowIndex >= totalRowCount && firstVisibleRowIndex > 0) {
       table.setPageIndex(Math.ceil(totalRowCount / pageSize) - 1);
     }
   }, [totalRowCount]);


### PR DESCRIPTION
```js
//if page index is out of bounds, set it to the last page
useEffect(() => {
  if (!enablePagination || isLoading || showSkeletons) return;
  const { pageIndex, pageSize } = pagination;
  const firstVisibleRowIndex = pageIndex * pageSize;
  if (firstVisibleRowIndex >= totalRowCount) {
    table.setPageIndex(Math.ceil(totalRowCount / pageSize) - 1);
  }
}, [totalRowCount]);
```

The logic within this `useEffect` is designed to detect when the `pageIndex` exceeds its valid range. If such an occurrence is detected, it resets to the last page. The second `if`statement within this logic, however, poses certain issues. If the current page is already the first one (with `pageIndex` being **0**) and the `totalRowCount` is **0** (indicating an empty table), this `if` statement would validate, but in fact, there is no need to invoke `setPageIndex` to reset to the last page because the current `pageIndex` is already the final page. This unnecessary invocation of `setPageIndex` not only creates redundant function calls but also leads to other issues.

We utilize **TanStack Query** to request data: `const query = useQuery(...)`, and we then pass `query.isLoading` into **MantineReactTable**. Due to the caching mechanism, `isLoading` only remains `true` during the **initial** query request; it is `false` **afterwards**. Should the **total** returned by this query remain **0**, it will trigger the aforementioned `if` logic, causing any component subsequent to the query request to initiate an **onPaginationChange** (triggered by the `setPageIndex` method) upon mounting.