### PR TITLE
fix: empty state text aligned left on grid layout mode

### DIFF
--- a/packages/mantine-react-table/src/components/body/MRT_TableBody.module.css
+++ b/packages/mantine-react-table/src/components/body/MRT_TableBody.module.css
@@ -21,6 +21,7 @@
 
 .empty-row-td-grid {
   display: grid;
+  width: inherit;
 }
 
 .empty-row-td-content {


### PR DESCRIPTION
If the layout mode is grid, the empty state text does not have full width therefore it is aligned to left. This solved the issue for e.

Before
<img width="614" alt="Screenshot 2025-01-09 at 16 22 13" src="https://github.com/user-attachments/assets/7262aa11-2a8d-455a-a8ef-26da00170e5c" />


After
<img width="1341" alt="image" src="https://github.com/user-attachments/assets/1028d86c-d2bb-4c98-b891-20c7cc872cbe" />
