### PR TITLE
Fix popover filter not closing on mouse click outside

### DIFF
--- a/packages/mantine-react-table/src/components/head/MRT_TableHeadCellFilterLabel.tsx
+++ b/packages/mantine-react-table/src/components/head/MRT_TableHeadCellFilterLabel.tsx
@@ -97,6 +97,7 @@ export const MRT_TableHeadCellFilterLabel = <TData extends MRT_RowData>({
     <>
       <Popover
         keepMounted={columnDef.filterVariant === 'range-slider'}
+        onChange={setPopoverOpened}
         onClose={() => setPopoverOpened(false)}
         opened={popoverOpened}
         position="top"


### PR DESCRIPTION
#483 

This fixes the issue when using 'popover' filtering and clicking outside. This is supposed to 'close' the filter but it seems since Mantine 7.13.3 it has not been the case.