### PR TITLE
Feature: Dont mount table row component of detail panel when not expanded

### DIFF
--- a/packages/mantine-react-table/src/components/body/MRT_TableDetailPanel.tsx
+++ b/packages/mantine-react-table/src/components/body/MRT_TableDetailPanel.tsx
@@ -74,6 +74,10 @@ export const MRT_TableDetailPanel = <TData extends MRT_RowData>({
     row.getIsExpanded() &&
     renderDetailPanel?.({ internalEditComponents, row, table });
 
+  if (!DetailPanel) {
+    return null;
+  }
+
   return (
     <TableTr
       data-index={

--- a/packages/mantine-react-table/src/components/body/MRT_TableDetailPanel.tsx
+++ b/packages/mantine-react-table/src/components/body/MRT_TableDetailPanel.tsx
@@ -74,10 +74,6 @@ export const MRT_TableDetailPanel = <TData extends MRT_RowData>({
     row.getIsExpanded() &&
     renderDetailPanel?.({ internalEditComponents, row, table });
 
-  if (!DetailPanel) {
-    return null;
-  }
-
   return (
     <TableTr
       data-index={

--- a/packages/mantine-react-table/stories/features/DetailPanel.stories.tsx
+++ b/packages/mantine-react-table/stories/features/DetailPanel.stories.tsx
@@ -1,4 +1,4 @@
-import { MantineReactTable } from '../../src';
+import { MantineReactTable, useMantineReactTable } from '../../src';
 
 import { faker } from '@faker-js/faker';
 import { type Meta } from '@storybook/react';
@@ -9,116 +9,88 @@ const meta: Meta = {
 
 export default meta;
 
-export const DetailPanelEnabled = () => (
-  <MantineReactTable
-    columns={[
-      {
-        accessorKey: 'firstName',
-        header: 'First Name',
-      },
-      {
-        accessorKey: 'lastName',
-        header: 'Last Name',
-      },
-      {
-        accessorKey: 'address',
-        header: 'Address',
-      },
-    ]}
-    data={[...Array(5)].map(() => ({
-      address: faker.location.streetAddress(),
-      city: faker.location.city(),
-      firstName: faker.person.firstName(),
-      lastName: faker.person.lastName(),
-      phone: faker.phone.number(),
-      state: faker.location.state(),
-      zipCode: faker.location.zipCode(),
-    }))}
-    renderDetailPanel={({ row }) => (
+const data = [...Array(5)].map(() => ({
+  address: faker.location.streetAddress(),
+  age: faker.number.int(100) + 5,
+  city: faker.location.city(),
+  firstName: faker.person.firstName(),
+  lastName: faker.person.lastName(),
+  phone: faker.phone.number(),
+  state: faker.location.state(),
+  zipCode: faker.location.zipCode(),
+}));
+
+const columns = [
+  {
+    accessorKey: 'firstName',
+    header: 'First Name',
+  },
+  {
+    accessorKey: 'lastName',
+    header: 'Last Name',
+  },
+  {
+    accessorKey: 'address',
+    header: 'Address',
+  },
+  {
+    accessorKey: 'age',
+    header: 'age',
+  },
+];
+
+export const DetailPanelEnabled = () => {
+  const table = useMantineReactTable({
+    columns,
+    data,
+    renderDetailPanel: ({ row }) => (
       <div style={{ display: 'grid' }}>
         <span>City: {row.original.city}</span>
         <span>State: {row.original.state}</span>
         <span>Zip: {row.original.zipCode}</span>
         <span>Phone: {row.original.phone}</span>
       </div>
-    )}
-  />
-);
+    ),
+  });
 
-export const CustomExpandRotation = () => (
-  <MantineReactTable
-    columns={[
-      {
-        accessorKey: 'firstName',
-        header: 'First Name',
-      },
-      {
-        accessorKey: 'lastName',
-        header: 'Last Name',
-      },
-      {
-        accessorKey: 'address',
-        header: 'Address',
-      },
-    ]}
-    data={[...Array(5)].map(() => ({
-      address: faker.location.streetAddress(),
-      city: faker.location.city(),
-      firstName: faker.person.firstName(),
-      lastName: faker.person.lastName(),
-      phone: faker.phone.number(),
-      state: faker.location.state(),
-      zipCode: faker.location.zipCode(),
-    }))}
-    enableExpandAll={false}
-    mantineExpandButtonProps={({ row }) => ({
+  return <MantineReactTable table={table} />;
+};
+
+export const CustomExpandRotation = () => {
+  const table = useMantineReactTable({
+    columns,
+    data,
+    enableExpandAll: false,
+    mantineExpandButtonProps: ({ row }) => ({
       style: {
         transform: row.getIsExpanded() ? 'rotate(-180deg)' : 'rotate(270deg)',
         transition: 'transform 0s',
       },
-    })}
-    renderDetailPanel={({ row }) => (
+    }),
+    renderDetailPanel: ({ row }) => (
       <div style={{ display: 'grid' }}>
         <span>City: {row.original.city}</span>
         <span>State: {row.original.state}</span>
         <span>Zip: {row.original.zipCode}</span>
         <span>Phone: {row.original.phone}</span>
       </div>
-    )}
-  />
-);
+    ),
+  });
 
-export const DetailPanelEnabledConditional = () => (
-  <MantineReactTable
-    columns={[
-      {
-        accessorKey: 'firstName',
-        header: 'First Name',
+  return <MantineReactTable table={table} />;
+};
+
+export const DetailPanelEnabledConditional = () => {
+  const table = useMantineReactTable({
+    columns,
+    data,
+    mantineExpandButtonProps: ({ row }) => ({
+      style: {
+        transform: row.getIsExpanded() ? 'rotate(-180deg)' : 'rotate(270deg)',
+        transition: 'transform 0s',
       },
-      {
-        accessorKey: 'lastName',
-        header: 'Last Name',
-      },
-      {
-        accessorKey: 'age',
-        header: 'Age',
-      },
-      {
-        accessorKey: 'address',
-        header: 'Address',
-      },
-    ]}
-    data={[...Array(10)].map(() => ({
-      address: faker.location.streetAddress(),
-      age: faker.number.int(100) + 5,
-      city: faker.location.city(),
-      firstName: faker.person.firstName(),
-      lastName: faker.person.lastName(),
-      phone: faker.phone.number(),
-      state: faker.location.state(),
-      zipCode: faker.location.zipCode(),
-    }))}
-    renderDetailPanel={({ row }) =>
+    }),
+    renderDetailPanel: ({ row }) =>
       row.original.age > 50 ? (
         <div style={{ display: 'grid' }}>
           <span>City: {row.original.city}</span>
@@ -126,47 +98,22 @@ export const DetailPanelEnabledConditional = () => (
           <span>Zip: {row.original.zipCode}</span>
           <span>Phone: {row.original.phone}</span>
         </div>
-      ) : undefined
-    }
-  />
-);
+      ) : undefined,
+  });
 
-export const DetailPanelEnabledConditionalHide = () => (
-  <MantineReactTable
-    columns={[
-      {
-        accessorKey: 'firstName',
-        header: 'First Name',
-      },
-      {
-        accessorKey: 'lastName',
-        header: 'Last Name',
-      },
-      {
-        accessorKey: 'age',
-        header: 'Age',
-      },
-      {
-        accessorKey: 'address',
-        header: 'Address',
-      },
-    ]}
-    data={[...Array(10)].map(() => ({
-      address: faker.location.streetAddress(),
-      age: faker.number.int(100) + 5,
-      city: faker.location.city(),
-      firstName: faker.person.firstName(),
-      lastName: faker.person.lastName(),
-      phone: faker.phone.number(),
-      state: faker.location.state(),
-      zipCode: faker.location.zipCode(),
-    }))}
-    mantineExpandButtonProps={({ row }) => ({
+  return <MantineReactTable table={table} />;
+};
+
+export const DetailPanelEnabledConditionalHide = () => {
+  const table = useMantineReactTable({
+    columns,
+    data,
+    mantineExpandButtonProps: ({ row }) => ({
       style: {
         display: row.original.age > 50 ? 'flex' : 'none',
       },
-    })}
-    renderDetailPanel={({ row }) =>
+    }),
+    renderDetailPanel: ({ row }) =>
       row.original.age > 50 ? (
         <div style={{ display: 'grid' }}>
           <span>City: {row.original.city}</span>
@@ -176,37 +123,17 @@ export const DetailPanelEnabledConditionalHide = () => (
         </div>
       ) : (
         'No details available'
-      )
-    }
-  />
-);
+      ),
+  });
 
-export const DetailPanelExpandColumnLast = () => (
-  <MantineReactTable
-    columns={[
-      {
-        accessorKey: 'firstName',
-        header: 'First Name',
-      },
-      {
-        accessorKey: 'lastName',
-        header: 'Last Name',
-      },
-      {
-        accessorKey: 'address',
-        header: 'Address',
-      },
-    ]}
-    data={[...Array(5)].map(() => ({
-      address: faker.location.streetAddress(),
-      city: faker.location.city(),
-      firstName: faker.person.firstName(),
-      lastName: faker.person.lastName(),
-      phone: faker.phone.number(),
-      state: faker.location.state(),
-      zipCode: faker.location.zipCode(),
-    }))}
-    displayColumnDefOptions={{
+  return <MantineReactTable table={table} />;
+};
+
+export const DetailPanelExpandColumnLast = () => {
+  const table = useMantineReactTable({
+    columns,
+    data,
+    displayColumnDefOptions: {
       'mrt-row-expand': {
         mantineTableBodyCellProps: {
           align: 'right',
@@ -215,89 +142,53 @@ export const DetailPanelExpandColumnLast = () => (
           align: 'right',
         },
       },
-    }}
-    positionExpandColumn="last"
-    renderDetailPanel={({ row }) => (
+    },
+    positionExpandColumn: 'last',
+    renderDetailPanel: ({ row }) => (
       <div style={{ display: 'grid' }}>
         <span>City: {row.original.city}</span>
         <span>State: {row.original.state}</span>
         <span>Zip: {row.original.zipCode}</span>
         <span>Phone: {row.original.phone}</span>
       </div>
-    )}
-  />
-);
+    ),
+  });
 
-export const DetailPanelExpandedByDefault = () => (
-  <MantineReactTable
-    columns={[
-      {
-        accessorKey: 'firstName',
-        header: 'First Name',
-      },
-      {
-        accessorKey: 'lastName',
-        header: 'Last Name',
-      },
-      {
-        accessorKey: 'address',
-        header: 'Address',
-      },
-    ]}
-    data={[...Array(5)].map(() => ({
-      address: faker.location.streetAddress(),
-      city: faker.location.city(),
-      firstName: faker.person.firstName(),
-      lastName: faker.person.lastName(),
-      phone: faker.phone.number(),
-      state: faker.location.state(),
-      zipCode: faker.location.zipCode(),
-    }))}
-    initialState={{ expanded: true }}
-    renderDetailPanel={({ row }) => (
-      <div style={{ display: 'grid' }}>
-        <span>City: {row.original.city}</span>
-        <span>State: {row.original.state}</span>
-        <span>Zip: {row.original.zipCode}</span>
-        <span>Phone: {row.original.phone}</span>
-      </div>
-    )}
-  />
-);
+  return <MantineReactTable table={table} />;
+};
 
-export const DetailPanelExpandAllDisabled = () => (
-  <MantineReactTable
-    columns={[
-      {
-        accessorKey: 'firstName',
-        header: 'First Name',
-      },
-      {
-        accessorKey: 'lastName',
-        header: 'Last Name',
-      },
-      {
-        accessorKey: 'address',
-        header: 'Address',
-      },
-    ]}
-    data={[...Array(5)].map(() => ({
-      address: faker.location.streetAddress(),
-      city: faker.location.city(),
-      firstName: faker.person.firstName(),
-      lastName: faker.person.lastName(),
-      phone: faker.phone.number(),
-      state: faker.location.state(),
-      zipCode: faker.location.zipCode(),
-    }))}
-    enableExpandAll={false}
-    renderDetailPanel={({ row }) => (
+export const DetailPanelExpandedByDefault = () => {
+  const table = useMantineReactTable({
+    columns,
+    data,
+    initialState: { expanded: true },
+    renderDetailPanel: ({ row }) => (
       <div style={{ display: 'grid' }}>
         <span>City: {row.original.city}</span>
         <span>State: {row.original.state}</span>
         <span>Zip: {row.original.zipCode}</span>
         <span>Phone: {row.original.phone}</span>
       </div>
-    )}
-  />
-);
+    ),
+  });
+
+  return <MantineReactTable table={table} />;
+};
+
+export const DetailPanelExpandAllDisabled = () => {
+  const table = useMantineReactTable({
+    columns,
+    data,
+    enableExpandAll: false,
+    renderDetailPanel: ({ row }) => (
+      <div style={{ display: 'grid' }}>
+        <span>City: {row.original.city}</span>
+        <span>State: {row.original.state}</span>
+        <span>Zip: {row.original.zipCode}</span>
+        <span>Phone: {row.original.phone}</span>
+      </div>
+    ),
+  });
+
+  return <MantineReactTable table={table} />;
+};


### PR DESCRIPTION
Previously, table row component would mount even if detail row is not expanded. This can cause the DOM to bloat rapidly.
A grid with 100 rows and a detail panel would create 100 extra DOM nodes.

Also fixed all detail panel stories.