### PR TITLE
Fix: Crash on dragging virtualized filtered table row

### DIFF
--- a/packages/mantine-react-table/src/hooks/useMRT_RowVirtualizer.ts
+++ b/packages/mantine-react-table/src/hooks/useMRT_RowVirtualizer.ts
@@ -60,7 +60,11 @@ export const useMRT_RowVirtualizer = <
     overscan: 4,
     rangeExtractor: useCallback(
       (range: Range) => {
-        return extraIndexRangeExtractor(range, draggingRow?.index ?? 0);
+        const current_index = getRowModel().rows.findIndex(
+          (row) => row.id === draggingRow?.id,
+        );
+
+        return extraIndexRangeExtractor(range, current_index >= 0 ? current_index: 0);
       },
       [draggingRow],
     ),


### PR DESCRIPTION
Came across this issue when I was trying to make use of the drag and drop between 2 virtualized tables. 

Once a filter is applied leaving a handful or 1 record consistently would crash and return index undefined. 
![image](https://github.com/user-attachments/assets/bd1563e9-7758-451d-97b6-6b44daae1e4d)

This small change will ensure it still operates the correct way and also deals with assigning an index correctly for the desired row sorting out the undefined issue so the drag and drop feature does not create an error.

have a good day and thanks for the awesome repo!