### PR TITLE
fix: multiply toolbar height by mantine scale

### DIFF
--- a/packages/mantine-react-table/src/components/toolbar/common.styles.module.css
+++ b/packages/mantine-react-table/src/components/toolbar/common.styles.module.css
@@ -2,7 +2,7 @@
   align-items: flex-start;
   display: grid;
   flex-wrap: wrap-reverse;
-  min-height: 3.5rem;
+  min-height: calc(3.5rem * var(--mantine-scale));
   overflow: visible;
   padding: 0;
   transition: all 150ms ease-in-out;


### PR DESCRIPTION
The toolbar min-height was not being multiplied by the --mantine-scale var.

Closes #431
