### PR TITLE
fix: Sort indicator not visible in light mode

### DIFF
--- a/packages/mantine-react-table/src/components/head/MRT_TableHeadCellSortLabel.tsx
+++ b/packages/mantine-react-table/src/components/head/MRT_TableHeadCellSortLabel.tsx
@@ -70,10 +70,11 @@ export const MRT_TableHeadCellSortLabel = <TData extends MRT_RowData>({
         SortActionButton
       ) : (
         <Indicator
-          className={clsx(
+          classNames={{
+            root: clsx(
             'mrt-table-head-multi-sort-indicator',
-            classes['multi-sort-indicator'],
-          )}
+            classes['multi-sort-indicator']
+            )}}
           inline
           label={sortIndex + 1}
           offset={4}


### PR DESCRIPTION
I noticed that the multi-sort indicators weren't visible on light-mode. After looking at the code, it appears the CSS classes were not being applied to the root element, as specified in the Mantine docs for the [Indicator component](https://mantine.dev/core/indicator/?t=styles-api).