### PR TITLE
Export utility function parseFromValuesOrFunc

### DIFF
--- a/packages/mantine-react-table/package.json
+++ b/packages/mantine-react-table/package.json
@@ -32,11 +32,11 @@
   "exports": {
     ".": {
       "import": {
-        "types": "./dist/index.d.cts",
+        "types": "./dist/index.esm.d.mts",
         "default": "./dist/index.esm.mjs"
       },
       "require": {
-        "types": "./dist/index.esm.d.mts",
+        "types": "./dist/index.d.cts",
         "default": "./dist/index.cjs"
       }
     },

--- a/packages/mantine-react-table/src/index.ts
+++ b/packages/mantine-react-table/src/index.ts
@@ -87,3 +87,4 @@ export * from './utils/row.utils';
 export * from './utils/style.utils';
 //helpers
 export * from './utils/tanstack.helpers';
+export * from './utils/utils';


### PR DESCRIPTION
This pull request contains:
* Export utility function `parseFromValuesOrFunc`
* Fix commonJS and ES6 export types in `package.json`

This pull request solves #517 