### PR TITLE
Fix: a11y - Add Missing aria-label to filter ActionIcon in MRT_TableHeadCell…

### DIFF
--- a/packages/mantine-react-table/src/components/head/MRT_TableHeadCellFilterLabel.tsx
+++ b/packages/mantine-react-table/src/components/head/MRT_TableHeadCellFilterLabel.tsx
@@ -125,6 +125,7 @@ export const MRT_TableHeadCellFilterLabel = <TData extends MRT_RowData>({
                 withinPortal
               >
                 <ActionIcon
+                  aria-label={filterTooltip}
                   className={clsx(
                     'mrt-table-head-cell-filter-label-icon',
                     classes.root,


### PR DESCRIPTION
…FilterLabel

Issue: The filter ActionIcon in individual columns is throwing an a11y error for missing a label
![image](https://github.com/user-attachments/assets/1f7d2378-763f-4f99-bb18-4419bbbbe09b)


Fix: Add aria-label with `filterTooltip` value to ActionIcon

