### PR TITLE
fix: use visibility hidden for global filter

### DIFF
--- a/packages/mantine-react-table/src/components/inputs/MRT_GlobalFilterTextInput.tsx
+++ b/packages/mantine-react-table/src/components/inputs/MRT_GlobalFilterTextInput.tsx
@@ -100,20 +100,22 @@ export const MRT_GlobalFilterTextInput = <TData extends MRT_RowData>({
         onChange={(event) => setSearchValue(event.target.value)}
         placeholder={localization.search}
         rightSection={
-          searchValue ? (
-            <ActionIcon
-              aria-label={localization.clearSearch}
-              color="gray"
-              disabled={!searchValue?.length}
-              onClick={handleClear}
-              size="sm"
-              variant="transparent"
-            >
-              <Tooltip label={localization.clearSearch} withinPortal>
-                <IconX />
-              </Tooltip>
-            </ActionIcon>
-          ) : null
+          <ActionIcon
+            aria-label={localization.clearSearch}
+            color="gray"
+            disabled={!searchValue?.length}
+            hidden={!searchValue}
+            onClick={handleClear}
+            size="sm"
+            style={{
+              visibility: !searchValue ? 'hidden' : undefined,
+            }}
+            variant="transparent"
+          >
+            <Tooltip label={localization.clearSearch} withinPortal>
+              <IconX />
+            </Tooltip>
+          </ActionIcon>
         }
         value={searchValue ?? ''}
         variant="filled"


### PR DESCRIPTION
Global filter was removing the clear button from the DOM which caused CLS, this uses the visibility property instead.

Closes #466
