### PR TITLE
fix: TypeError when clicking range-slider filter in popover mode

### DIFF
--- a/packages/mantine-react-table/src/components/head/MRT_TableHeadCellFilterLabel.tsx
+++ b/packages/mantine-react-table/src/components/head/MRT_TableHeadCellFilterLabel.tsx
@@ -142,7 +142,9 @@ export const MRT_TableHeadCellFilterLabel = <TData extends MRT_RowData>({
                     setTimeout(() => {
                       const input = filterInputRefs.current[`${column.id}-0`];
                       input?.focus();
-                      input?.select();
+                      if (typeof input?.select === 'function') {
+                        input.select();
+                      }
                     }, 100);
                   }}
                   {...rest}

--- a/packages/mantine-react-table/stories/fixed-bugs/range-slider-popover-bug.stories.tsx
+++ b/packages/mantine-react-table/stories/fixed-bugs/range-slider-popover-bug.stories.tsx
@@ -1,0 +1,122 @@
+import { useMemo } from 'react';
+import { type Meta } from '@storybook/react';
+import {
+  MantineReactTable,
+  useMantineReactTable,
+  type MRT_ColumnDef,
+} from '../../src';
+
+const meta: Meta = {
+  title: 'Fixed Bugs/Range Slider Popover Bug',
+};
+
+export default meta;
+
+type Person = {
+  name: string;
+  salary: number;
+  city: string;
+  state: string;
+};
+
+const data: Person[] = [
+  {
+    name: 'John Doe',
+    salary: 100000,
+    city: 'New York',
+    state: 'New York',
+  },
+  {
+    name: 'Jane Smith',
+    salary: 80000,
+    city: 'Los Angeles',
+    state: 'California',
+  },
+  {
+    name: 'Bob Johnson',
+    salary: 120000,
+    city: 'Chicago',
+    state: 'Illinois',
+  },
+  {
+    name: 'Alice Brown',
+    salary: 95000,
+    city: 'Houston',
+    state: 'Texas',
+  },
+];
+
+/**
+ * Bug: TypeError: input.select is not a function
+ * 
+ * Steps to reproduce:
+ * 1. Set columnFilterDisplayMode to 'popover'
+ * 2. Add a column with filterVariant: 'range-slider'
+ * 3. Click the filter icon in the Salary column header
+ * 4. Before fix: TypeError would be thrown
+ * 5. After fix: Popover opens without error
+ * 
+ * Root cause: MRT_TableHeadCellFilterLabel.tsx assumed all inputs have select() method
+ * Fix: Added type check before calling input.select()
+ */
+export const RangeSliderPopoverBugFixed = () => {
+  const columns = useMemo<MRT_ColumnDef<Person>[]>(
+    () => [
+      {
+        accessorKey: 'name',
+        header: 'Name',
+        filterVariant: 'text', // This works fine
+      },
+      {
+        accessorKey: 'salary',
+        header: 'Salary (Click filter icon to test)',
+        filterVariant: 'range-slider', // This caused the bug
+        Cell: ({ cell }) =>
+          cell.getValue<number>().toLocaleString('en-US', {
+            style: 'currency',
+            currency: 'USD',
+          }),
+        mantineFilterRangeSliderProps: {
+          color: 'blue',
+          step: 10000,
+          label: (value) =>
+            value.toLocaleString('en-US', {
+              style: 'currency',
+              currency: 'USD',
+            }),
+        },
+      },
+      {
+        accessorKey: 'city',
+        header: 'City',
+        filterVariant: 'select', // This works fine
+      },
+      {
+        accessorKey: 'state',
+        header: 'State',
+        filterVariant: 'multi-select', // This works fine
+      },
+    ],
+    [],
+  );
+
+  const table = useMantineReactTable({
+    columns,
+    data,
+    columnFilterDisplayMode: 'popover', // Required to trigger the bug
+    initialState: { showColumnFilters: true },
+  });
+
+  return (
+    <div>
+      <div style={{ marginBottom: '16px', padding: '12px', backgroundColor: '#f0f8ff', border: '1px solid #0066cc', borderRadius: '4px' }}>
+        <strong>Bug Test:</strong> Click the filter icon in the "Salary" column header. 
+        <br />
+        <strong>Before fix:</strong> Would throw "TypeError: input.select is not a function"
+        <br />
+        <strong>After fix:</strong> Popover opens normally without error
+      </div>
+      <MantineReactTable table={table} />
+    </div>
+  );
+};


### PR DESCRIPTION
Since I use the MRT almost every day, I quickly identified the bug in #534 and provided a fix.

## Bug Fix: TypeError in Range Slider Popover

Fixes #534

### Issue
`TypeError: input.select is not a function` occurs when clicking filter button for range-slider columns in popover mode.

### Solution
Added type check before calling `input.select()` to prevent error on range-slider inputs.

### Testing
See Storybook story: `Fixed Bugs/Range Slider Popover Bug`
