### PR TITLE
fix: Turkish translation: replace 'of' with '/' for pagination

### DIFF
--- a/packages/mantine-react-table/src/locales/tr.ts
+++ b/packages/mantine-react-table/src/locales/tr.ts
@@ -59,7 +59,7 @@ export const MRT_Localization_TR: MRT_Localization = {
   move: 'Taşı',
   noRecordsToDisplay: 'Gösterilecek Kayıt Yok',
   noResultsFound: 'Herhangi Bir Sonuç Bulunamadı',
-  of: 'of',
+  of: '/',
   or: 'veya',
   pin: 'Sabitle',
   pinToLeft: 'Sola Sabitle',


### PR DESCRIPTION
Looks like the 'of' key was forgotten while translating. Most natural way of translating it would be just using a slash just like the [Finnish translation](https://github.com/KevinVandy/mantine-react-table/blob/d338579598b52a93045a96c55eacadfc8db331bb/packages/mantine-react-table/src/locales/fi.ts#L63).