### PR TITLE
Fix Suggests Edits Button Anchor Text Color

### DIFF
--- a/apps/mantine-react-table-docs/components/mdx/SuggestsEditButton.module.css
+++ b/apps/mantine-react-table-docs/components/mdx/SuggestsEditButton.module.css
@@ -16,7 +16,7 @@
 }
 
 .materialUiAnchor {
-  background-image: linear-gradient(to right, var(--TODO), var(--TODO));
+  background-image: linear-gradient(to right, var(--mantine-primary-color-filled), var(--mantine-color-cyan-text));
   display: inline;
   -webkit-background-clip: text;
   background-clip: text;
@@ -24,6 +24,6 @@
   text-decoration: none;
   &:hover {
     text-decoration: underline;
-    text-decoration-color: var(--TODO);
+    text-decoration-color: var(--mantine-primary-color-filled);
   }
 }

--- a/apps/mantine-react-table-docs/components/mdx/SuggestsEditsButton.tsx
+++ b/apps/mantine-react-table-docs/components/mdx/SuggestsEditsButton.tsx
@@ -38,7 +38,6 @@ export const SuggestsEditsButton = () => {
       <Text className={classes.materialUi}>
         Using{' '}
         <Anchor
-          color="blue.6"
           href="https://mui.com/"
           target="_blank"
           rel="noopener"


### PR DESCRIPTION
## Issue:

Hey there. In the doc pages, one of the suggested anchors displayed with transparent color that causing poor readability against certain backgrounds.

This PR assigns a temporary solid color to the anchor text to ensure consistent visibility and prevent transparency issues.
A permanent design-aligned color can be set later if needed.

<img width="340" height="80" alt="image" src="https://github.com/user-attachments/assets/591b0a6d-1faf-449d-9055-f2075b5f482e" />

<img width="340" height="80" alt="image" src="https://github.com/user-attachments/assets/576d4afb-6ef9-4f26-a1b4-1d4e399bf572" />
