### PR TITLE
Fix row selection using row virtualizer and memo mode rows

### DIFF
--- a/packages/mantine-react-table/src/components/body/MRT_TableBodyRow.tsx
+++ b/packages/mantine-react-table/src/components/body/MRT_TableBodyRow.tsx
@@ -258,5 +258,4 @@ export const MRT_TableBodyRow = <TData extends MRT_RowData>({
 
 export const Memo_MRT_TableBodyRow = memo(
   MRT_TableBodyRow,
-  (prev, next) => prev.row === next.row,
 ) as typeof MRT_TableBodyRow;


### PR DESCRIPTION
This pull request contains:

* remove optional arePropsEqual check from mrt table body row. 
* Use default comparison of every property with Object.is

This pull request solves #549 