### PR TITLE
about page 'fasted' ➡️ 'fastest'

### DIFF
--- a/apps/mantine-react-table-docs/pages/about.mdx
+++ b/apps/mantine-react-table-docs/pages/about.mdx
@@ -19,7 +19,7 @@ Mantine React Table is a fully featured Mantine implementation of TanStack React
 
 Mantine React Table (MRT) is a fully-featured data grid/table component library for React built on [TanStack Table V8's](https://react-table.tanstack.com/) powerful API. MRT is meant to work best in projects already using [Mantine](https://mantine.dev/) components, but it is not necessarily required. However, be aware that [Mantine](https://mantine.dev/) and [Emotion](https://emotion.sh/) are required as peer dependencies for MRT to work.
 
-MRT is built from the ground up in TypeScript, and is designed to have a great type-safe dev experience with generics that react to the data structures you pass in. TypeScript is not at all required to use MRT, but it is recommended for the best and fasted developer experience, especially when defining columns.
+MRT is built from the ground up in TypeScript, and is designed to have a great type-safe dev experience with generics that react to the data structures you pass in. TypeScript is not at all required to use MRT, but it is recommended for the best and fastest developer experience, especially when defining columns.
 
 ### Motivation
 


### PR DESCRIPTION
**What is changed?**

`./apps/mantine-react-table-docs/pages/about.mdx`

Typo 'fasted' becomes 'fastest' on v1 [about page](https://www.mantine-react-table.com/about).

**Note**

The same typo also exists on v2 and v3 branches. If desired, I will PR each. You decide.

Thank you for reviewing.